### PR TITLE
Improve Grand Prix resume flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
       <div class="menuActions">
         <button id="newRaceBtn" class="primary">Schnelles Rennen</button>
         <button id="grandPrixBtn">Grand Prix (5 Rennen)</button>
+        <button id="resetGpBtn">Neuen GP starten</button>
         <button id="managerBtn">Team Karriere</button>
         <button id="bettingBtn">Race Betting Challenge</button>
         <button id="teamsBtn">Teams &amp; Fahrer</button>

--- a/script.js
+++ b/script.js
@@ -505,6 +505,7 @@
 
   const newRaceBtn = document.getElementById('newRaceBtn');
   const grandPrixBtn = document.getElementById('grandPrixBtn');
+  const resetGpBtn = document.getElementById('resetGpBtn');
   const managerBtn = document.getElementById('managerBtn');
   const bettingBtn = document.getElementById('bettingBtn');
   const teamsBtn = document.getElementById('teamsBtn');
@@ -2509,15 +2510,19 @@
     if (gpActive) {
       gpAccumulate(order);
       gpRaceIndex += 1;
-      let text = resultsLabel.textContent;
-      text += gpStandingsText();
-      if (gpRaceIndex < GP_RACES) {
-        nextRaceBtn.style.display = 'inline-block';
+      gpActive = gpRaceIndex < GP_RACES;
+      gpSave();
+      let text = `${resultsLabel.textContent}\n\n${gpStandingsText()}`;
+      if (gpActive) {
+        const upcomingTrackId = gpTrackRotation[gpRaceIndex % gpTrackRotation.length];
+        const upcomingLabel = trackCatalog[upcomingTrackId]?.label || upcomingTrackId;
+        text += `\n\nNächstes Rennen: ${upcomingLabel} (Rennen ${gpRaceIndex + 1}/${GP_RACES})`;
+        if (nextRaceBtn) nextRaceBtn.style.display = 'inline-block';
       } else {
-        gpActive = false;
-        text += '\nGP abgeschlossen.';
+        text += '\n\nGP abgeschlossen.';
+        if (nextRaceBtn) nextRaceBtn.style.display = 'none';
       }
-      resultsLabel.textContent = text;
+      resultsLabel.textContent = text.trim();
     }
     if (currentMode === 'manager') {
       applyManagerRewards(order);
@@ -2531,12 +2536,9 @@
     logRaceControl('Rennen beendet – Ergebnisse verfügbar', 'success');
   }
 
-  function gpReset() {
-    gpActive = true;
-    gpRaceIndex = 0;
-    gpTable.clear();
-    gpSave();
-    currentTrackType = gpTrackRotation[0];
+  function syncRaceSetupForTrack(trackId) {
+    if (!trackId) return;
+    currentTrackType = trackId;
     if (trackTypeSelect) {
       trackTypeSelect.value = currentTrackType;
     }
@@ -2547,6 +2549,14 @@
     refreshOddsTable();
   }
 
+  function gpReset() {
+    gpActive = true;
+    gpRaceIndex = 0;
+    gpTable.clear();
+    gpSave();
+    syncRaceSetupForTrack(gpTrackRotation[0]);
+  }
+
   function gpAccumulate(order) {
     order.forEach((car, idx) => {
       if (!gpTable.has(car.driver)) {
@@ -2555,16 +2565,88 @@
       const pts = GP_POINTS[idx] || 0;
       gpTable.get(car.driver).points += pts;
     });
-    gpSave();
   }
 
   function gpStandingsText() {
     const arr = Array.from(gpTable.values()).sort((a, b) => b.points - a.points);
-    let text = `\nGP Zwischenstand nach Rennen ${gpRaceIndex}/${GP_RACES}:\n`;
+    const completedRaces = Math.min(gpRaceIndex, GP_RACES);
+    const heading = gpRaceIndex >= GP_RACES && arr.length
+      ? `GP Endstand (${GP_RACES} Rennen):`
+      : `GP Zwischenstand nach Rennen ${completedRaces}/${GP_RACES}:`;
+    let text = `${heading}\n`;
     arr.slice(0, 10).forEach((entry, idx) => {
       text += `${idx + 1}. #${entry.number} ${entry.driver} (${entry.team}) – ${entry.points} P\n`;
     });
-    return text;
+    return text.trimEnd();
+  }
+
+  function formatGpStatusText() {
+    const entryCount = gpTable.size;
+    const hasProgress = entryCount > 0 && gpRaceIndex < GP_RACES;
+    const isFinished = entryCount > 0 && gpRaceIndex >= GP_RACES;
+    if (isFinished) {
+      return `${gpStandingsText()}\nGP abgeschlossen.`.trim();
+    }
+    if (hasProgress) {
+      const upcomingTrackId = gpTrackRotation[gpRaceIndex % gpTrackRotation.length];
+      const upcomingLabel = trackCatalog[upcomingTrackId]?.label || upcomingTrackId;
+      return `${gpStandingsText()}\nNächstes Rennen: ${upcomingLabel} (Rennen ${gpRaceIndex + 1}/${GP_RACES})`.trim();
+    }
+    const firstTrackId = gpTrackRotation[0];
+    const firstLabel = trackCatalog[firstTrackId]?.label || firstTrackId;
+    return `Grand Prix vorbereitet – Auftakt auf ${firstLabel}.`;
+  }
+
+  function prepareGpLobbyState({ fromResume = false } = {}) {
+    hideGridIntro();
+    if (countdownTimer) {
+      clearInterval(countdownTimer);
+      countdownTimer = null;
+    }
+    countdownRunning = false;
+    raceActive = false;
+    isPaused = false;
+    setRacePhase('IDLE');
+    if (sessionInfo) {
+      sessionInfo.classList.add('hidden');
+      sessionInfo.textContent = '';
+    }
+    if (pauseRaceBtn) {
+      pauseRaceBtn.textContent = 'Pause';
+      pauseRaceBtn.disabled = true;
+    }
+    if (startRaceBtn) {
+      startRaceBtn.disabled = false;
+    }
+    if (replayRaceBtn) {
+      replayRaceBtn.style.display = 'none';
+    }
+    leaderGapHud?.classList.add('hidden');
+    if (highlightTicker) {
+      highlightTicker.textContent = '';
+    }
+    if (top3Banner) {
+      top3Banner.textContent = '';
+      top3Banner.classList.add('hidden');
+    }
+    resetRaceControlLog();
+    const trackIndex = gpRaceIndex < GP_RACES ? gpRaceIndex : GP_RACES - 1;
+    const trackId = gpTrackRotation[trackIndex % gpTrackRotation.length];
+    syncRaceSetupForTrack(trackId);
+    if (resultsLabel) {
+      resultsLabel.textContent = formatGpStatusText();
+    }
+    if (nextRaceBtn) {
+      if (gpRaceIndex > 0 && gpRaceIndex < GP_RACES && gpTable.size > 0) {
+        nextRaceBtn.style.display = 'inline-block';
+      } else {
+        nextRaceBtn.style.display = 'none';
+      }
+    }
+    gpActive = gpRaceIndex < GP_RACES && (gpTable.size > 0 || gpRaceIndex === 0);
+    if (fromResume && gpRaceIndex >= GP_RACES) {
+      gpActive = false;
+    }
   }
 
   function gpSave() {
@@ -2581,10 +2663,11 @@
       const raw = localStorage.getItem(STORAGE_KEYS.gp);
       if (!raw) return;
       const obj = JSON.parse(raw);
-      gpRaceIndex = obj.gpRaceIndex || 0;
+      gpRaceIndex = Math.min(Math.max(obj.gpRaceIndex || 0, 0), GP_RACES);
       gpTable.clear();
       (obj.data || []).forEach(([key, value]) => gpTable.set(key, value));
-      gpActive = gpRaceIndex > 0 && gpRaceIndex < GP_RACES;
+      const hasEntries = gpTable.size > 0;
+      gpActive = gpRaceIndex < GP_RACES && hasEntries;
     } catch (err) {
       console.warn('gp load failed', err);
     }
@@ -3159,7 +3242,29 @@
 
   grandPrixBtn?.addEventListener('click', () => {
     currentMode = 'gp';
+    const hasEntries = gpTable.size > 0;
+    const canResume = hasEntries && gpRaceIndex < GP_RACES;
+    const finished = hasEntries && gpRaceIndex >= GP_RACES;
+    if (canResume || finished) {
+      prepareGpLobbyState({ fromResume: true });
+    } else {
+      gpReset();
+      prepareGpLobbyState();
+    }
+    showScreen(raceScreen);
+  });
+
+  resetGpBtn?.addEventListener('click', () => {
+    const hasEntries = gpTable.size > 0;
+    if (hasEntries) {
+      const confirmReset = confirm('Aktuellen Grand Prix wirklich zurücksetzen? Fortschritt geht verloren.');
+      if (!confirmReset) {
+        return;
+      }
+    }
+    currentMode = 'gp';
     gpReset();
+    prepareGpLobbyState();
     showScreen(raceScreen);
   });
 


### PR DESCRIPTION
## Summary
- add a dedicated "Neuen GP starten" control so players can reset championships intentionally
- resume stored Grand Prix state by syncing track selection, standings text, and controls when returning to the race screen
- persist GP progress after each race to avoid losing points between sessions

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ca62689d8c8324b6d1369078bdbf9f

## Summary by Sourcery

Improve the Grand Prix flow by adding a dedicated reset control, persisting state between sessions, and synchronizing the UI when resuming or finishing a stored championship

New Features:
- Add a “Neuen GP starten” button to reset Grand Prix sessions intentionally
- Persist Grand Prix progress to localStorage after each race
- Allow resuming or completing a stored Grand Prix when reopening the race screen

Enhancements:
- Revamp Grand Prix lobby setup to sync track selection, standings text, and control visibility on resume
- Improve formatting of intermediate and final standings with upcoming race details
- Clamp loaded race index within valid bounds and refine gpActive logic