### PR TITLE
Ensure GP rounds advance when using start button

### DIFF
--- a/script.js
+++ b/script.js
@@ -3304,6 +3304,9 @@
     resultsLabel.textContent = '';
     replayRaceBtn.style.display = 'none';
     if (nextRaceBtn) nextRaceBtn.style.display = 'none';
+    if (currentMode === 'gp' && gpActive) {
+      prepareGrandPrixRound();
+    }
     setStartButtonState(false);
     setPauseButtonState(false, 'Pause');
     racePhaseMeta = {};


### PR DESCRIPTION
## Summary
- call `prepareGrandPrixRound` when starting a session in GP mode so the next rotation track is loaded even if the main start button is used

## Testing
- not run (UI-driven)


------
https://chatgpt.com/codex/tasks/task_e_68cb4223398c832488ebf474641720c4