### PR TITLE
Ensure GP start uses next circuit

### DIFF
--- a/script.js
+++ b/script.js
@@ -3262,6 +3262,9 @@
   }
 
   function startRace() {
+    if (currentMode === 'gp' && gpActive && gpRaceIndex < GP_RACES) {
+      prepareGrandPrixRound();
+    }
     hidePodiumOverlay(true);
     clearReplayData();
     recordingReplay = true;


### PR DESCRIPTION
## Summary
- update the main start handler to refresh the GP track rotation before each race when a championship is active
- ensure launching a GP event from the regular start button loads the next circuit and keeps the UI in sync

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb4223c0d4832495c1c1eee6f72c33

## Summary by Sourcery

Bug Fixes:
- Prepare the next GP round in startRace for active championships to load the correct circuit and keep the UI in sync