### PR TITLE
Add Vanguard concept art set for new Spacer-X circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ Futuristisches Top‑Down‑Racing mit TV‑UI, 18 Strecken (u. a. Atlas Skywa
 - `index.html` – UI & Screens (Main Menu, Race, Teams, Settings)
 - `styles.css` – Dark/Neo‑Noir Theme, Banner, Ticker, Mini‑Map
 - `script.js` – Game‑Core (Track, Cars, Flags, GP‑Flow, UI Bindings)
+- `assets/sprites/track_concepts.svg` – Poster-Konzepte für Aurora Skyway, Ion Spine & Solar Cascade
+- `assets/sprites/track_concepts_set2.svg` – Panorama-Triptychon mit Comet Trench, Quantum Bloom & Umbra Expanse
+- `assets/sprites/track_concepts_set3.svg` – Stadion-Triptychon mit Luminaria Circuit, Ion Velodrome & Parallax Forum
+- `assets/sprites/space_glider_pixelart.svg` – Pixelart-Sheet für die neuen Aether-Lance- & Violet-Flare-Gleiter
+- `assets/sprites/space_glider_pixelart_set2.svg` – Vanguard-Pixelset für Prism Rider, Eclipse Talon & Grav Seraph
+- `assets/sprites/space_glider_pixelart_set3.svg` – Vanguard-Pixelset für Zenith Wyvern, Halo Riptide & Comet Barricade
+- `assets/sprites/team_crests.svg` – Wappen-Set für Aurora Wardens, Nova Paladins, Ember Vanguard, Tidal Oracle, Prism Lilith & Greenline Rally
+- `assets/scenes/track_blueprint_panel.svg` – Blueprint-Panel mit Strecken-Notizen für Broadcast & Manager-Modus
+- `assets/scenes/track_keyart_triptych.svg` – Key-Art-Triptychon als atmosphärisches Widescreen-Konzept der neuen Kurse
+- `assets/scenes/track_grandstand_panorama.svg` – Stadion-Atmosphäre mit Neon-Tribünen, Sponsorflächen und Oval-Linienführung
+- `assets/dlc_pack/` – DLC-Ordner mit frischen Kurs-Postern, Blueprints, Broadcast-Overlays, Teamwappen & Gleiter-Konzepten
+- `assets/dlc_pack/dlc_track_posters.svg` – Poster-Trio für Nova Rift, Cygnus Spiral & Obsidian Mirage samt DLC-Branding
+- `assets/dlc_pack/dlc_track_blueprints.svg` – Blueprint-Cluster für Helix Downforce, Solaris Vortex & Lagrange Drift
+- `assets/dlc_pack/dlc_track_environments.svg` – Skyline-Parallaxen und Tribünen für Aurora Skyway, Nebula Spiral & Lagrange Drift
+- `assets/dlc_pack/dlc_space_gliders.svg` – Pixel-Garage mit Photon Lynx, Nebula Aegis & Meteor Viper inkl. Spec-Notes
+- `assets/dlc_pack/dlc_broadcast_overlay_kit.svg` – Overlay-Paket (Lower Third, Pit Panel, Intro-Bumper) für TV-Produktionen
+- `assets/dlc_pack/dlc_team_logos.svg` – Neues Crest-Set (Lynx Pulse, Orbit Seraph, Verdant Arrow, Nova Mirror, Quantum Warden, Ember Vector)
 
 ## Steuerung
 - Alles per UI (Start/Pause/Replay/Nächstes Rennen)

--- a/assets/dlc_pack/dlc_broadcast_overlay_kit.svg
+++ b/assets/dlc_pack/dlc_broadcast_overlay_kit.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 900">
+  <rect width="1400" height="900" fill="#02030a"/>
+  <defs>
+    <linearGradient id="overlayGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0a1a35"/>
+      <stop offset="100%" stop-color="#1e0f35"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#42f5ff"/>
+      <stop offset="100%" stop-color="#5f5cff"/>
+    </linearGradient>
+    <linearGradient id="accent2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff6ee0"/>
+      <stop offset="100%" stop-color="#ff9f4a"/>
+    </linearGradient>
+  </defs>
+  <g font-family="'Orbitron', 'Arial', sans-serif" fill="#f1f4ff" text-anchor="middle">
+    <text x="700" y="80" font-size="40" letter-spacing="10">SPACER-X BROADCAST OVERLAY KIT</text>
+    <text x="700" y="120" font-size="20" fill="#6ddcff" letter-spacing="4">DLC CIRCUIT PACK 01 // PRODUCTION PACKAGE</text>
+  </g>
+  <g>
+    <rect x="120" y="160" width="520" height="160" rx="24" fill="url(#overlayGradient)" stroke="#42f5ff" stroke-width="3"/>
+    <polygon points="120,160 200,160 170,320 120,320" fill="#42f5ff" opacity="0.35"/>
+    <polygon points="640,160 560,160 590,320 640,320" fill="#5f5cff" opacity="0.35"/>
+    <text x="380" y="220" font-family="'Rajdhani', 'Arial', sans-serif" font-size="28" fill="#c8f8ff" text-anchor="middle">RACE HUD LOWER THIRD</text>
+    <text x="380" y="260" font-family="'Roboto Mono', monospace" font-size="16" fill="#7ddcff" text-anchor="middle">INSERT DRIVER + SPLIT + ENERGY</text>
+  </g>
+  <g>
+    <rect x="760" y="160" width="520" height="160" rx="24" fill="url(#overlayGradient)" stroke="#ff6ee0" stroke-width="3"/>
+    <polygon points="760,160 820,160 800,320 760,320" fill="#ff6ee0" opacity="0.25"/>
+    <polygon points="1280,160 1220,160 1240,320 1280,320" fill="#ff9f4a" opacity="0.25"/>
+    <text x="1020" y="220" font-family="'Rajdhani', 'Arial', sans-serif" font-size="28" fill="#ffdfff" text-anchor="middle">PIT STRATEGY PANEL</text>
+    <text x="1020" y="260" font-family="'Roboto Mono', monospace" font-size="16" fill="#ffb1e8" text-anchor="middle">TYRES • CHARGE • WINDOW</text>
+  </g>
+  <g>
+    <rect x="120" y="360" width="520" height="200" rx="28" fill="#060d1e" stroke="#42f5ff" stroke-width="2"/>
+    <rect x="140" y="380" width="480" height="80" rx="16" fill="#091738"/>
+    <rect x="140" y="470" width="480" height="70" rx="16" fill="#101d40"/>
+    <text x="380" y="420" font-family="'Press Start 2P', monospace" font-size="18" fill="#71e8ff" text-anchor="middle">LAP DELTA STACK</text>
+    <text x="380" y="505" font-family="'Roboto Mono', monospace" font-size="16" fill="#a0d8ff" text-anchor="middle">+00.152  |  ENERGY 78%  |  BOOST READY</text>
+  </g>
+  <g>
+    <rect x="760" y="360" width="520" height="200" rx="28" fill="#180622" stroke="#ff6ee0" stroke-width="2"/>
+    <rect x="780" y="380" width="480" height="150" rx="20" fill="#2a0b3a"/>
+    <text x="1020" y="440" font-family="'Press Start 2P', monospace" font-size="18" fill="#ff9ff4" text-anchor="middle">OVERTAKE ALERT</text>
+    <text x="1020" y="495" font-family="'Roboto Mono', monospace" font-size="16" fill="#ffc2f7" text-anchor="middle">FLASH • SHAKE • AUDIO PING</text>
+  </g>
+  <g>
+    <rect x="120" y="600" width="1160" height="220" rx="32" fill="#060d1e" stroke="#5f5cff" stroke-width="3"/>
+    <rect x="140" y="620" width="1120" height="60" rx="26" fill="#091736"/>
+    <rect x="140" y="690" width="540" height="110" rx="26" fill="#101f45"/>
+    <rect x="720" y="690" width="540" height="110" rx="26" fill="#1a264f"/>
+    <text x="700" y="660" font-family="'Rajdhani', 'Arial', sans-serif" font-size="26" fill="#d2ddff" text-anchor="middle">DLC CIRCUIT INTRO BUMPER</text>
+    <text x="410" y="750" font-family="'Roboto Mono', monospace" font-size="16" fill="#98beff" text-anchor="middle">LEFT: TRACK STATS / WEATHER / HAZARD</text>
+    <text x="980" y="750" font-family="'Roboto Mono', monospace" font-size="16" fill="#a0a8ff" text-anchor="middle">RIGHT: TEAM CRESTS / GRID SHUFFLE</text>
+  </g>
+  <g font-family="'Roboto Mono', monospace" font-size="14" fill="#4ca4ff">
+    <text x="120" y="840">NOTES: INCLUDE ANIMATED NEBULA PARTICLES &amp; WIPE-SYNC AUDIO. DELIVER AS ALPHA PNG + SVG.</text>
+  </g>
+</svg>

--- a/assets/dlc_pack/dlc_space_gliders.svg
+++ b/assets/dlc_pack/dlc_space_gliders.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800">
+  <rect width="1200" height="800" fill="#05030f"/>
+  <defs>
+    <linearGradient id="panelGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#10122a"/>
+      <stop offset="100%" stop-color="#1e2a5a"/>
+    </linearGradient>
+  </defs>
+  <rect x="60" y="80" width="1080" height="640" rx="32" fill="url(#panelGradient)" stroke="#2e5cff" stroke-width="3"/>
+  <g font-family="'Orbitron', 'Arial', sans-serif" font-weight="600" fill="#e7f0ff" text-anchor="middle">
+    <text x="600" y="140" font-size="36" letter-spacing="8">VANGUARD // DLC GLIDER BAY</text>
+    <text x="600" y="180" font-size="18" fill="#86b6ff" letter-spacing="4">PIXEL AERODYNAMICS - REV 5.4</text>
+  </g>
+  <g font-family="'Press Start 2P', monospace" font-size="16" fill="#ffe66d">
+    <text x="260" y="220">PHOTON LYNX</text>
+    <text x="600" y="220">NEBULA AEGIS</text>
+    <text x="940" y="220">METEOR VIPER</text>
+  </g>
+  <g>
+    <rect x="140" y="240" width="240" height="320" rx="18" fill="#141a3a" stroke="#30f5ff" stroke-width="2"/>
+    <rect x="480" y="240" width="240" height="320" rx="18" fill="#1a143a" stroke="#ff6edb" stroke-width="2"/>
+    <rect x="820" y="240" width="240" height="320" rx="18" fill="#1a2810" stroke="#8dff6e" stroke-width="2"/>
+  </g>
+  <g shape-rendering="crispEdges">
+    <g transform="translate(160,260)">
+      <rect x="0" y="0" width="200" height="200" fill="#1a2644" stroke="#30f5ff" stroke-width="1"/>
+      <rect x="10" y="80" width="180" height="40" fill="#162040"/>
+      <polygon points="20,110 60,70 120,70 180,110 150,140 50,140" fill="#4ce1ff"/>
+      <polygon points="60,70 90,40 140,40 120,70" fill="#85f9ff"/>
+      <rect x="40" y="120" width="120" height="16" fill="#0b132c"/>
+      <rect x="70" y="90" width="60" height="16" fill="#10264f"/>
+      <rect x="90" y="60" width="22" height="10" fill="#30f5ff"/>
+      <rect x="48" y="146" width="104" height="12" fill="#30f5ff" opacity="0.5"/>
+      <text x="100" y="190" text-anchor="middle" font-family="'Press Start 2P', monospace" font-size="10" fill="#80f8ff">AURA DUAL-LANCE</text>
+    </g>
+    <g transform="translate(500,260)">
+      <rect x="0" y="0" width="200" height="200" fill="#2a143e" stroke="#ff6edb" stroke-width="1"/>
+      <rect x="18" y="90" width="164" height="36" fill="#210b36"/>
+      <polygon points="30,120 80,70 120,70 170,120 130,150 70,150" fill="#ff8de0"/>
+      <polygon points="80,70 100,40 130,40 120,70" fill="#ffd0f6"/>
+      <rect x="68" y="120" width="64" height="14" fill="#350a43"/>
+      <rect x="58" y="96" width="84" height="12" fill="#461255"/>
+      <rect x="92" y="60" width="18" height="10" fill="#ff6edb"/>
+      <rect x="60" y="148" width="80" height="12" fill="#ff6edb" opacity="0.5"/>
+      <text x="100" y="190" text-anchor="middle" font-family="'Press Start 2P', monospace" font-size="10" fill="#ffd6ff">ARC-SHIELD VECTOR</text>
+    </g>
+    <g transform="translate(840,260)">
+      <rect x="0" y="0" width="200" height="200" fill="#1e2a16" stroke="#8dff6e" stroke-width="1"/>
+      <rect x="14" y="88" width="172" height="40" fill="#172410"/>
+      <polygon points="30,122 76,70 124,70 170,122 136,150 64,150" fill="#a6ff72"/>
+      <polygon points="76,70 102,42 132,42 124,70" fill="#d2ffb6"/>
+      <rect x="70" y="120" width="60" height="14" fill="#1a2a12"/>
+      <rect x="62" y="96" width="76" height="12" fill="#253b16"/>
+      <rect x="96" y="60" width="18" height="10" fill="#8dff6e"/>
+      <rect x="68" y="148" width="72" height="12" fill="#8dff6e" opacity="0.5"/>
+      <text x="100" y="190" text-anchor="middle" font-family="'Press Start 2P', monospace" font-size="10" fill="#d4ffd0">KINETIC TALON</text>
+    </g>
+  </g>
+  <g font-family="'Roboto Mono', monospace" font-size="14" fill="#9bc9ff">
+    <text x="260" y="590">• flux intake • anti-grav blade • lynx fins</text>
+    <text x="600" y="590">• radiant canopy • particle shield • arc spoilers</text>
+    <text x="940" y="590">• thermal spine • vipershard wings • thrust lattices</text>
+  </g>
+  <g font-family="'Roboto Mono', monospace" font-size="12" fill="#586bff">
+    <text x="260" y="620">SPRINT SPECS: 840 KPH PEAK / 5.8G STABLE</text>
+    <text x="600" y="620">DEFENSE SPECS: 770 KPH PEAK / SHIELD 92%</text>
+    <text x="940" y="620">ASSAULT SPECS: 910 KPH PEAK / 6.5G STABLE</text>
+  </g>
+  <g font-family="'Rajdhani', 'Arial', sans-serif" font-size="16" fill="#6a84ff" text-anchor="middle">
+    <text x="600" y="690">INTEGRATED FOR DLC CIRCUIT PACK 01 // DEPLOY VIA GARAGE PATCH</text>
+  </g>
+</svg>

--- a/assets/dlc_pack/dlc_team_logos.svg
+++ b/assets/dlc_pack/dlc_team_logos.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 700">
+  <rect width="1400" height="700" fill="#04040c"/>
+  <g font-family="'Orbitron', 'Arial', sans-serif" fill="#ffffff" text-anchor="middle">
+    <text x="700" y="70" font-size="40" letter-spacing="12">DLC TEAM CREST COLLECTION</text>
+    <text x="700" y="110" font-size="20" fill="#7ddcff" letter-spacing="6">PACK 01 // CONSTELLATION BRIGADE</text>
+  </g>
+  <g transform="translate(140,160)">
+    <rect x="0" y="0" width="340" height="200" rx="24" fill="#0f1d3a" stroke="#4ffbff" stroke-width="2"/>
+    <polygon points="60,60 120,20 180,60 200,110 120,180 40,110" fill="#0a3459"/>
+    <polygon points="120,50 160,80 140,130 120,160 100,130 80,80" fill="#4ffbff"/>
+    <circle cx="120" cy="110" r="18" fill="#0a1226" stroke="#4ffbff" stroke-width="4"/>
+    <text x="250" y="90" font-family="'Rajdhani', 'Arial', sans-serif" font-size="30" fill="#bff9ff">LYNX PULSE</text>
+    <text x="250" y="130" font-family="'Roboto Mono', monospace" font-size="14" fill="#7ddcff">KINETIC RESPONSE UNIT</text>
+  </g>
+  <g transform="translate(520,160)">
+    <rect x="0" y="0" width="340" height="200" rx="24" fill="#220c38" stroke="#ff7ce4" stroke-width="2"/>
+    <polygon points="60,150 120,30 180,150" fill="#34104d"/>
+    <polygon points="60,150 120,70 180,150" fill="#ff7ce4"/>
+    <polygon points="80,140 120,90 160,140" fill="#ffb3f4"/>
+    <text x="250" y="90" font-family="'Rajdhani', 'Arial', sans-serif" font-size="30" fill="#ffc6fe">ORBIT SERAPH</text>
+    <text x="250" y="130" font-family="'Roboto Mono', monospace" font-size="14" fill="#ff9cea">STELLAR GUARD DETAIL</text>
+  </g>
+  <g transform="translate(900,160)">
+    <rect x="0" y="0" width="340" height="200" rx="24" fill="#1a2a0c" stroke="#8dff6e" stroke-width="2"/>
+    <polygon points="80,60 160,20 240,60 210,140 110,140" fill="#233810"/>
+    <polygon points="100,70 160,40 220,70 200,120 120,120" fill="#8dff6e"/>
+    <polygon points="120,85 160,60 200,85 188,110 132,110" fill="#c9ffb4"/>
+    <text x="250" y="90" font-family="'Rajdhani', 'Arial', sans-serif" font-size="30" fill="#cfffad">VERDANT ARROW</text>
+    <text x="250" y="130" font-family="'Roboto Mono', monospace" font-size="14" fill="#a0ff92">BIO-THRUST COLLECTIVE</text>
+  </g>
+  <g transform="translate(140,380)">
+    <rect x="0" y="0" width="340" height="200" rx="24" fill="#0f0f2a" stroke="#6d5cff" stroke-width="2"/>
+    <circle cx="120" cy="100" r="80" fill="#1a1a48"/>
+    <path d="M120 40 L160 80 L120 160 L80 120 Z" fill="#6d5cff"/>
+    <path d="M120 60 L145 85 L120 140 L95 115 Z" fill="#b1a9ff"/>
+    <text x="250" y="90" font-family="'Rajdhani', 'Arial', sans-serif" font-size="30" fill="#c9c3ff">NOVA MIRROR</text>
+    <text x="250" y="130" font-family="'Roboto Mono', monospace" font-size="14" fill="#a8a0ff">REFRACTION SYNDICATE</text>
+  </g>
+  <g transform="translate(520,380)">
+    <rect x="0" y="0" width="340" height="200" rx="24" fill="#0f1f1f" stroke="#42f5ff" stroke-width="2"/>
+    <polygon points="120,30 190,80 160,170 80,170 50,80" fill="#123030"/>
+    <polygon points="120,50 172,86 148,150 92,150 68,86" fill="#42f5ff"/>
+    <polygon points="120,70 156,96 140,140 100,140 84,96" fill="#a0fcff"/>
+    <text x="250" y="90" font-family="'Rajdhani', 'Arial', sans-serif" font-size="30" fill="#bdfaff">QUANTUM WARDEN</text>
+    <text x="250" y="130" font-family="'Roboto Mono', monospace" font-size="14" fill="#8ce6ff">SINGULARITY DEFENSE</text>
+  </g>
+  <g transform="translate(900,380)">
+    <rect x="0" y="0" width="340" height="200" rx="24" fill="#230f16" stroke="#ff945c" stroke-width="2"/>
+    <polygon points="60,140 120,40 200,40 220,140 140,180" fill="#331a1e"/>
+    <polygon points="80,130 130,60 190,60 204,130 140,160" fill="#ff945c"/>
+    <polygon points="100,120 140,70 180,70 192,120 140,145" fill="#ffd3b6"/>
+    <text x="250" y="90" font-family="'Rajdhani', 'Arial', sans-serif" font-size="30" fill="#ffbe94">EMBER VECTOR</text>
+    <text x="250" y="130" font-family="'Roboto Mono', monospace" font-size="14" fill="#ffb884">THERMAL STRIKE TEAM</text>
+  </g>
+</svg>

--- a/assets/dlc_pack/dlc_track_blueprints.svg
+++ b/assets/dlc_pack/dlc_track_blueprints.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 800">
+  <defs>
+    <linearGradient id="gridGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0a1a3a"/>
+      <stop offset="100%" stop-color="#020812"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <rect width="40" height="40" fill="none" stroke="#15346b" stroke-width="0.6"/>
+    </pattern>
+  </defs>
+  <rect width="1400" height="800" fill="url(#gridGradient)"/>
+  <rect x="40" y="40" width="1320" height="720" fill="url(#grid)" opacity="0.4"/>
+  <g font-family="'Rajdhani', 'Arial', sans-serif" fill="#8fb9ff">
+    <text x="700" y="90" font-size="34" letter-spacing="8" text-anchor="middle">DLC TRACK BLUEPRINT CLUSTER</text>
+    <text x="700" y="130" font-size="18" text-anchor="middle" fill="#4aa2ff">REVISION 3.2 // HELIX PROGRAM</text>
+  </g>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <g transform="translate(140,220)">
+      <rect x="0" y="0" width="360" height="360" rx="26" fill="rgba(10,36,74,0.6)" stroke="#1c5cff" stroke-width="2"/>
+      <text x="180" y="42" fill="#b8d9ff" font-family="'Orbitron', 'Arial', sans-serif" font-size="22" text-anchor="middle">HELIX DOWNFORCE</text>
+      <path d="M80 280 C30 200 120 120 200 140 C300 170 340 260 260 320 C200 360 130 340 80 280" stroke="#4aa2ff" stroke-width="5"/>
+      <circle cx="115" cy="205" r="8" fill="#4aa2ff"/>
+      <circle cx="260" cy="300" r="8" fill="#4aa2ff"/>
+      <text x="180" y="330" font-family="'Roboto Mono', monospace" font-size="14" fill="#6dbdff" text-anchor="middle">VERTICAL FLUX RAMPS // MAGNETIC HAIRPINS</text>
+    </g>
+    <g transform="translate(520,220)">
+      <rect x="0" y="0" width="360" height="360" rx="26" fill="rgba(12,26,68,0.6)" stroke="#ff7c4a" stroke-width="2"/>
+      <text x="180" y="42" fill="#ffd2b8" font-family="'Orbitron', 'Arial', sans-serif" font-size="22" text-anchor="middle">SOLARIS VORTEX</text>
+      <path d="M110 110 Q210 40 280 120 T280 260 Q220 340 140 300 T70 170" stroke="#ff9468" stroke-width="5"/>
+      <circle cx="210" cy="90" r="8" fill="#ff9468"/>
+      <circle cx="160" cy="280" r="8" fill="#ff9468"/>
+      <text x="180" y="330" font-family="'Roboto Mono', monospace" font-size="14" fill="#ffcfa5" text-anchor="middle">SOLAR MIRROR STRAIGHTS // VORTEX LOOP</text>
+    </g>
+    <g transform="translate(900,220)">
+      <rect x="0" y="0" width="360" height="360" rx="26" fill="rgba(6,20,52,0.6)" stroke="#73ffb6" stroke-width="2"/>
+      <text x="180" y="42" fill="#cbffe6" font-family="'Orbitron', 'Arial', sans-serif" font-size="22" text-anchor="middle">LAGRANGE DRIFT</text>
+      <path d="M80 150 C60 100 150 60 230 90 C300 120 320 180 280 240 C240 300 150 320 120 270" stroke="#73ffb6" stroke-width="5"/>
+      <circle cx="135" cy="120" r="8" fill="#73ffb6"/>
+      <circle cx="260" cy="250" r="8" fill="#73ffb6"/>
+      <text x="180" y="330" font-family="'Roboto Mono', monospace" font-size="14" fill="#a0ffd7" text-anchor="middle">ZEROG DRIFT ARCHES // LAGRANGE TRANSFER</text>
+    </g>
+  </g>
+  <g font-family="'Roboto Mono', monospace" font-size="16" fill="#4aa2ff">
+    <text x="220" y="640">NOTES: EXPAND CROWD CAPACITY WITH MODULAR TRIBUNE / INSTALL HELIX SUPPORT LIGHTS</text>
+    <text x="220" y="670">BROADCAST: UPDATE TRACK HUD COLORS TO MATCH NEW SPECTRUM IDS</text>
+    <text x="220" y="700">QA: TEST NIGHT WEATHER &amp; PARTICLE DENSITY ON SOLARIS VORTEX LOOP SEQUENCE</text>
+  </g>
+  <g font-family="'Rajdhani', 'Arial', sans-serif" font-size="18" fill="#4aa2ff">
+    <text x="1180" y="640" text-anchor="end">// DLC PACK 01 : ASTRAL RUSH</text>
+    <text x="1180" y="670" text-anchor="end">// DELIVERABLE: PATCH 2.6.1</text>
+    <text x="1180" y="700" text-anchor="end">// ARCHIVE GRID SNAPSHOT</text>
+  </g>
+</svg>

--- a/assets/dlc_pack/dlc_track_environments.svg
+++ b/assets/dlc_pack/dlc_track_environments.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 600">
+  <rect width="1400" height="600" fill="#01040d"/>
+  <defs>
+    <linearGradient id="sky1" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#101a46"/>
+      <stop offset="100%" stop-color="#050918"/>
+    </linearGradient>
+    <linearGradient id="sky2" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#220c3a"/>
+      <stop offset="100%" stop-color="#070313"/>
+    </linearGradient>
+    <linearGradient id="sky3" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#152b1e"/>
+      <stop offset="100%" stop-color="#050b0a"/>
+    </linearGradient>
+  </defs>
+  <g>
+    <rect x="40" y="60" width="420" height="480" rx="24" fill="url(#sky1)" stroke="#3ad9ff" stroke-width="2"/>
+    <rect x="40" y="360" width="420" height="80" rx="18" fill="#081027"/>
+    <rect x="40" y="430" width="420" height="80" rx="18" fill="#091a32"/>
+    <circle cx="140" cy="140" r="18" fill="#fff3a0"/>
+    <polygon points="60,420 110,360 210,330 320,360 380,420" fill="#0f1a3a"/>
+    <polygon points="80,420 130,380 200,360 300,380 360,420" fill="#1b3454" opacity="0.7"/>
+    <text x="250" y="520" font-family="'Rajdhani', 'Arial', sans-serif" font-size="20" fill="#98e7ff" text-anchor="middle">AURORA SKYWAY - SKYLINE PASS</text>
+  </g>
+  <g>
+    <rect x="490" y="60" width="420" height="480" rx="24" fill="url(#sky2)" stroke="#ff6ede" stroke-width="2"/>
+    <rect x="490" y="360" width="420" height="80" rx="18" fill="#190628"/>
+    <rect x="490" y="430" width="420" height="80" rx="18" fill="#2a0b3c"/>
+    <circle cx="580" cy="140" r="14" fill="#ffa8f0"/>
+    <polygon points="520,420 600,340 690,320 760,360 830,420" fill="#2a0b3c"/>
+    <polygon points="540,420 610,360 700,340 750,360 810,420" fill="#ff6ede" opacity="0.45"/>
+    <text x="700" y="520" font-family="'Rajdhani', 'Arial', sans-serif" font-size="20" fill="#ffb1f6" text-anchor="middle">NEBULA SPIRAL - STELLAR TERRACES</text>
+  </g>
+  <g>
+    <rect x="940" y="60" width="420" height="480" rx="24" fill="url(#sky3)" stroke="#8dff6e" stroke-width="2"/>
+    <rect x="940" y="360" width="420" height="80" rx="18" fill="#0c1c11"/>
+    <rect x="940" y="430" width="420" height="80" rx="18" fill="#18351f"/>
+    <circle cx="1040" cy="140" r="16" fill="#b6ff9e"/>
+    <polygon points="980,420 1060,350 1140,330 1240,360 1320,420" fill="#12301b"/>
+    <polygon points="1000,420 1070,360 1140,340 1220,360 1290,420" fill="#8dff6e" opacity="0.35"/>
+    <text x="1150" y="520" font-family="'Rajdhani', 'Arial', sans-serif" font-size="20" fill="#baffb4" text-anchor="middle">LAGRANGE DRIFT - ORBITAL GARDENS</text>
+  </g>
+  <g font-family="'Roboto Mono', monospace" font-size="14" fill="#4db4ff">
+    <text x="60" y="560">ENVIRONMENT PASS 1.1  //  PARALLAX LAYERS + CROWD BAYS</text>
+  </g>
+</svg>

--- a/assets/dlc_pack/dlc_track_posters.svg
+++ b/assets/dlc_pack/dlc_track_posters.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 600">
+  <rect width="1200" height="600" fill="#040612"/>
+  <g font-family="'Orbitron', 'Arial', sans-serif" font-weight="600" text-anchor="middle" fill="#ffffff">
+    <text x="200" y="70" font-size="28" letter-spacing="4">NOVA RIFT</text>
+    <text x="600" y="70" font-size="28" letter-spacing="4">CYGNUS SPIRAL</text>
+    <text x="1000" y="70" font-size="28" letter-spacing="4">OBSIDIAN MIRAGE</text>
+  </g>
+  <g fill="none" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="40" y="100" width="320" height="440" rx="28" fill="url(#novaGradient)" stroke="#58f6ff" stroke-width="2"/>
+    <rect x="440" y="100" width="320" height="440" rx="28" fill="url(#cygnusGradient)" stroke="#ffd95e" stroke-width="2"/>
+    <rect x="840" y="100" width="320" height="440" rx="28" fill="url(#obsidianGradient)" stroke="#ff6ec7" stroke-width="2"/>
+  </g>
+  <defs>
+    <linearGradient id="novaGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#071124"/>
+      <stop offset="45%" stop-color="#142e5a"/>
+      <stop offset="100%" stop-color="#31d2ff"/>
+    </linearGradient>
+    <linearGradient id="cygnusGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#160029"/>
+      <stop offset="45%" stop-color="#321573"/>
+      <stop offset="100%" stop-color="#ffd65a"/>
+    </linearGradient>
+    <linearGradient id="obsidianGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#050509"/>
+      <stop offset="45%" stop-color="#181033"/>
+      <stop offset="100%" stop-color="#ff3f9f"/>
+    </linearGradient>
+  </defs>
+  <g stroke="#58f6ff" stroke-width="4" fill="none" opacity="0.95">
+    <path d="M110 220 C180 160 260 160 300 240 S250 420 150 420 C90 410 70 360 100 320"/>
+    <circle cx="150" cy="220" r="6" fill="#58f6ff"/>
+    <circle cx="270" cy="320" r="6" fill="#58f6ff"/>
+  </g>
+  <g stroke="#ffd95e" stroke-width="4" fill="none" opacity="0.95">
+    <path d="M510 420 C460 350 500 250 580 240 C640 230 680 280 690 340 C705 440 580 480 520 420"/>
+    <circle cx="580" cy="240" r="6" fill="#ffd95e"/>
+    <circle cx="660" cy="360" r="6" fill="#ffd95e"/>
+  </g>
+  <g stroke="#ff6ec7" stroke-width="4" fill="none" opacity="0.95">
+    <path d="M910 220 Q960 160 1030 210 T1090 350 Q1030 420 970 380 T900 260"/>
+    <circle cx="960" cy="200" r="6" fill="#ff6ec7"/>
+    <circle cx="1050" cy="360" r="6" fill="#ff6ec7"/>
+  </g>
+  <g font-family="'Rajdhani', 'Arial', sans-serif" fill="#dff6ff" font-size="16">
+    <text x="200" y="520">Graviton Shear • Rift Gate Sprint • Dyna-Lux Crowd Pods</text>
+    <text x="600" y="520">Orbital Bloom • Lensing Arcs • S-Curve Chase</text>
+    <text x="1000" y="520">Obsidian Sandstorm • Mirage Gate • Echoing Apex</text>
+  </g>
+  <g font-family="'Roboto Mono', monospace" font-size="13" fill="#9bdcff" letter-spacing="2">
+    <text x="200" y="150" text-anchor="middle">DLC CIRCUIT PACK // 01</text>
+    <text x="600" y="150" text-anchor="middle">DLC CIRCUIT PACK // 01</text>
+    <text x="1000" y="150" text-anchor="middle">DLC CIRCUIT PACK // 01</text>
+  </g>
+</svg>

--- a/assets/scenes/track_blueprint_panel.svg
+++ b/assets/scenes/track_blueprint_panel.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="420" viewBox="0 0 1200 420" role="img" aria-labelledby="title desc">
+  <title id="title">Spacer-X Track Blueprint Panel</title>
+  <desc id="desc">Konzeptart für drei futuristische Rennstrecken mit Beschleunigungszonen und Notizen.</desc>
+  <defs>
+    <linearGradient id="panelBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="gridLines" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="420" rx="28" fill="url(#panelBg)"/>
+  <g transform="translate(48 48)" font-family="'Rajdhani', sans-serif">
+    <rect x="0" y="0" width="336" height="324" rx="20" fill="#040c1a" stroke="#1f2937" stroke-width="2"/>
+    <rect x="0" y="0" width="336" height="324" rx="20" fill="url(#gridLines)" opacity="0.35"/>
+    <g fill="none" stroke="#38f9d7" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M60 248 C82 170 150 132 210 150 C250 162 272 206 276 244 C280 282 248 300 216 300 C184 300 150 276 126 256"/>
+      <path d="M80 252 C106 196 158 170 200 182 C242 194 260 236 262 262" stroke-dasharray="12 12" opacity="0.6"/>
+      <circle cx="60" cy="248" r="9" fill="#22d3ee"/>
+      <circle cx="262" cy="262" r="9" fill="#22d3ee"/>
+    </g>
+    <text x="24" y="44" fill="#a5f3fc" font-size="26" letter-spacing="0.22em">AURORA SKYWAY</text>
+    <text x="24" y="74" fill="#bae6fd" font-size="16">• Polar Wind Shear erzeugt Hochgeschwindigkeits-Seitendrifts</text>
+    <text x="24" y="98" fill="#bae6fd" font-size="16">• Antigrav-Ringe heben den Pulk vor Sektor 3 an</text>
+    <text x="24" y="122" fill="#bae6fd" font-size="16">• Wechselnde Nordlichtfelder stören Sensorik</text>
+  </g>
+  <g transform="translate(432 48)" font-family="'Rajdhani', sans-serif">
+    <rect x="0" y="0" width="336" height="324" rx="20" fill="#12011f" stroke="#2d1b4f" stroke-width="2"/>
+    <rect x="0" y="0" width="336" height="324" rx="20" fill="url(#gridLines)" opacity="0.35"/>
+    <g fill="none" stroke="#f472b6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M68 256 C94 182 152 142 214 118 C260 100 304 128 300 188 C296 248 260 288 210 306 C160 324 108 300 84 268"/>
+      <path d="M94 252 C124 204 182 168 232 156 C268 148 290 166 288 198" stroke-dasharray="12 12" opacity="0.55"/>
+      <circle cx="68" cy="256" r="9" fill="#f472b6"/>
+      <circle cx="288" cy="198" r="9" fill="#f472b6"/>
+    </g>
+    <text x="24" y="44" fill="#f9a8d4" font-size="26" letter-spacing="0.22em">ION SPINE</text>
+    <text x="24" y="74" fill="#fbcfe8" font-size="16">• Bioleuchtende Tunnel mit Refraktions-Gefahren</text>
+    <text x="24" y="98" fill="#fbcfe8" font-size="16">• Doppelhelix-Loop verlangt perfekte Boost-Synchronisation</text>
+    <text x="24" y="122" fill="#fbcfe8" font-size="16">• Magnetische Ströme verschieben Ideallinie</text>
+  </g>
+  <g transform="translate(816 48)" font-family="'Rajdhani', sans-serif">
+    <rect x="0" y="0" width="336" height="324" rx="20" fill="#1f0a00" stroke="#7c2d12" stroke-width="2"/>
+    <rect x="0" y="0" width="336" height="324" rx="20" fill="url(#gridLines)" opacity="0.35"/>
+    <g fill="none" stroke="#facc15" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M58 250 C90 170 154 110 218 126 C266 138 306 200 296 250 C286 300 236 318 188 314 C140 310 92 284 74 258"/>
+      <path d="M90 242 C122 184 178 146 230 164 C270 178 290 214 284 248" stroke-dasharray="12 12" opacity="0.6"/>
+      <circle cx="58" cy="250" r="9" fill="#facc15"/>
+      <circle cx="284" cy="248" r="9" fill="#facc15"/>
+    </g>
+    <text x="24" y="44" fill="#ffedd5" font-size="26" letter-spacing="0.22em">SOLAR CASCADE</text>
+    <text x="24" y="74" fill="#fed7aa" font-size="16">• Lavafall-Sprung mit Staffel-Boosts</text>
+    <text x="24" y="98" fill="#fed7aa" font-size="16">• Hitze-Korridore verlangen Kühldrift-Management</text>
+    <text x="24" y="122" fill="#fed7aa" font-size="16">• Heliostat-Felder reflektieren Gegner-Positionen</text>
+  </g>
+  <text x="600" y="380" fill="#38bdf8" font-family="'Orbitron', sans-serif" font-size="20" text-anchor="middle" letter-spacing="0.24em">ADVANCED TRACK OPS · FIELD DOSSIER</text>
+</svg>

--- a/assets/scenes/track_grandstand_panorama.svg
+++ b/assets/scenes/track_grandstand_panorama.svg
@@ -1,0 +1,121 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="480" viewBox="0 0 1440 480" role="img" aria-labelledby="title desc">
+  <title id="title">Spacer-X Arena Grandstand Panorama</title>
+  <desc id="desc">Widescreen-Visual mit vollbesetzten Publikumsrängen, Neon-Sponsorflächen und einem zentralen Rennoval.</desc>
+  <defs>
+    <linearGradient id="nightSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="60%" stop-color="#0b1733"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="trackGlow" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="50%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+    <linearGradient id="seatGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1f2937"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="neonRibbon" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="50%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#f97316"/>
+    </linearGradient>
+    <linearGradient id="infield" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#042f2e"/>
+      <stop offset="100%" stop-color="#0f766e"/>
+    </linearGradient>
+    <radialGradient id="lightPylon" cx="0.5" cy="0" r="1">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.65"/>
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="crowdDots" x="0" y="0" width="18" height="12" patternUnits="userSpaceOnUse">
+      <rect width="18" height="12" fill="none"/>
+      <circle cx="4" cy="4" r="1.2" fill="#38bdf8" opacity="0.55"/>
+      <circle cx="9" cy="6" r="1.2" fill="#f472b6" opacity="0.6"/>
+      <circle cx="14" cy="3" r="1.2" fill="#fde68a" opacity="0.55"/>
+      <circle cx="7" cy="9" r="1.1" fill="#c084fc" opacity="0.5"/>
+    </pattern>
+  </defs>
+
+  <rect width="1440" height="480" fill="url(#nightSky)"/>
+  <g opacity="0.35">
+    <rect width="1440" height="480" fill="#0f172a"/>
+    <rect width="1440" height="480" fill="url(#crowdDots)"/>
+  </g>
+
+  <g transform="translate(0 60)">
+    <polygon points="-40,120 1440,120 1440,80 -40,80" fill="#0f172a" opacity="0.5"/>
+    <polygon points="-60,180 1440,180 1440,120 -60,120" fill="#020617" opacity="0.9"/>
+    <polygon points="-80,240 1440,240 1440,180 -80,180" fill="url(#seatGradient)"/>
+    <polygon points="-120,312 1440,312 1440,240 -120,240" fill="url(#seatGradient)" opacity="0.8"/>
+    <polygon points="-160,360 1440,360 1440,312 -160,312" fill="url(#seatGradient)" opacity="0.75"/>
+
+    <g fill="url(#crowdDots)" opacity="0.85">
+      <polygon points="-80,240 1440,240 1440,180 -80,180"/>
+      <polygon points="-120,312 1440,312 1440,240 -120,240"/>
+      <polygon points="-160,360 1440,360 1440,312 -160,312"/>
+    </g>
+
+    <g fill="url(#neonRibbon)" opacity="0.85">
+      <rect x="-80" y="220" width="1520" height="6" rx="3"/>
+      <rect x="-120" y="292" width="1600" height="6" rx="3"/>
+      <rect x="-160" y="340" width="1680" height="6" rx="3"/>
+    </g>
+
+    <g fill="#1f2937" opacity="0.7">
+      <rect x="40" y="188" width="140" height="34" rx="8"/>
+      <rect x="240" y="188" width="140" height="34" rx="8"/>
+      <rect x="440" y="188" width="140" height="34" rx="8"/>
+      <rect x="640" y="188" width="140" height="34" rx="8"/>
+      <rect x="840" y="188" width="140" height="34" rx="8"/>
+      <rect x="1040" y="188" width="140" height="34" rx="8"/>
+      <rect x="1240" y="188" width="140" height="34" rx="8"/>
+    </g>
+
+    <g fill="#38bdf8" opacity="0.8">
+      <rect x="60" y="196" width="96" height="18" rx="6"/>
+      <rect x="260" y="196" width="96" height="18" rx="6"/>
+      <rect x="460" y="196" width="96" height="18" rx="6"/>
+      <rect x="660" y="196" width="96" height="18" rx="6"/>
+      <rect x="860" y="196" width="96" height="18" rx="6"/>
+      <rect x="1060" y="196" width="96" height="18" rx="6"/>
+      <rect x="1260" y="196" width="96" height="18" rx="6"/>
+    </g>
+  </g>
+
+  <g transform="translate(0 120)">
+    <ellipse cx="720" cy="258" rx="520" ry="150" fill="#020817" stroke="#38bdf8" stroke-width="6" opacity="0.8"/>
+    <ellipse cx="720" cy="258" rx="450" ry="118" fill="url(#trackGlow)" stroke="#a855f7" stroke-width="6" opacity="0.9"/>
+    <ellipse cx="720" cy="258" rx="320" ry="80" fill="url(#infield)" opacity="0.95"/>
+    <ellipse cx="720" cy="258" rx="220" ry="52" fill="#064e3b" opacity="0.8"/>
+
+    <g fill="none" stroke="#0ea5e9" stroke-width="4" stroke-dasharray="18 14" opacity="0.7">
+      <ellipse cx="720" cy="258" rx="520" ry="150"/>
+      <ellipse cx="720" cy="258" rx="450" ry="118"/>
+    </g>
+
+    <g fill="#38bdf8" opacity="0.6">
+      <circle cx="220" cy="190" r="10"/>
+      <circle cx="1240" cy="200" r="10"/>
+      <circle cx="720" cy="370" r="10"/>
+    </g>
+
+    <g fill="#38bdf8" opacity="0.45">
+      <path d="M220 190 L220 90" stroke="#38bdf8" stroke-width="6" stroke-linecap="round" opacity="0.5"/>
+      <path d="M1240 200 L1240 90" stroke="#38bdf8" stroke-width="6" stroke-linecap="round" opacity="0.5"/>
+    </g>
+
+    <g opacity="0.85">
+      <rect x="212" y="86" width="16" height="120" fill="#0f172a"/>
+      <rect x="1232" y="86" width="16" height="120" fill="#0f172a"/>
+      <rect x="712" y="58" width="16" height="146" fill="#0f172a"/>
+      <ellipse cx="220" cy="86" rx="36" ry="12" fill="url(#lightPylon)"/>
+      <ellipse cx="1240" cy="86" rx="36" ry="12" fill="url(#lightPylon)"/>
+      <ellipse cx="720" cy="58" rx="42" ry="16" fill="url(#lightPylon)"/>
+    </g>
+  </g>
+
+  <text x="80" y="84" fill="#38bdf8" font-family="'Orbitron', sans-serif" font-size="36" letter-spacing="0.28em">STADIUM ATMOSPHERE</text>
+  <text x="80" y="120" fill="#e0f2fe" font-family="'Rajdhani', sans-serif" font-size="20" opacity="0.85">Publikumstribünen · Neon-Sponsoren · Ringförmige Rennlinie</text>
+</svg>

--- a/assets/scenes/track_keyart_triptych.svg
+++ b/assets/scenes/track_keyart_triptych.svg
@@ -1,0 +1,137 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="520" viewBox="0 0 1440 520" role="img" aria-labelledby="title desc">
+  <title id="title">Spacer-X Key Art Triptych</title>
+  <desc id="desc">Widescreen-Konzeptillustrationen der neuen Strecken-Atmosphären für Comet Trench, Quantum Bloom und Umbra Expanse.</desc>
+  <defs>
+    <linearGradient id="nightSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="100%" stop-color="#0b1120"/>
+    </linearGradient>
+    <linearGradient id="panelOverlay" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="panelBase" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="520" rx="32" fill="url(#nightSky)"/>
+  <g transform="translate(40 40)">
+    <g transform="translate(0 0)">
+      <rect width="440" height="440" rx="30" fill="url(#panelBase)" stroke="#1e293b" stroke-width="3"/>
+      <rect width="440" height="440" rx="30" fill="url(#panelOverlay)"/>
+      <g clip-path="url(#clipComet)">
+        <defs>
+          <clipPath id="clipComet"><rect width="440" height="440" rx="30"/></clipPath>
+          <linearGradient id="cometHorizon" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#061124"/>
+            <stop offset="50%" stop-color="#0a274a"/>
+            <stop offset="100%" stop-color="#0f325c"/>
+          </linearGradient>
+          <linearGradient id="cometGround" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#06121f"/>
+            <stop offset="100%" stop-color="#0d233a"/>
+          </linearGradient>
+          <linearGradient id="cometGlow" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="#38bdf8" stop-opacity="0"/>
+            <stop offset="50%" stop-color="#38bdf8" stop-opacity="0.8"/>
+            <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
+          </linearGradient>
+        </defs>
+        <rect width="440" height="440" fill="url(#cometHorizon)"/>
+        <g opacity="0.4" fill="#7dd3fc">
+          <circle cx="320" cy="80" r="4"/>
+          <circle cx="340" cy="110" r="6"/>
+          <circle cx="360" cy="92" r="3"/>
+          <circle cx="300" cy="50" r="5"/>
+          <circle cx="260" cy="70" r="4"/>
+        </g>
+        <path d="M0 260 C80 200 180 184 260 200 C340 216 400 244 440 232 V440 H0 Z" fill="url(#cometGround)"/>
+        <path d="M0 320 C100 280 220 260 320 280 C360 288 420 310 440 316" fill="none" stroke="#38bdf8" stroke-width="6" stroke-linecap="round"/>
+        <path d="M0 332 C120 292 240 284 340 302 C380 309 420 322 440 330" fill="none" stroke="#bae6fd" stroke-width="4" stroke-linecap="round" stroke-dasharray="16 14" opacity="0.7"/>
+        <rect x="60" y="156" width="180" height="12" rx="6" fill="#38bdf8" opacity="0.4"/>
+        <rect x="220" y="140" width="120" height="10" rx="5" fill="#bae6fd" opacity="0.35"/>
+        <rect x="160" y="120" width="140" height="10" rx="5" fill="#67e8f9" opacity="0.45"/>
+        <rect x="0" y="280" width="440" height="160" fill="url(#cometGlow)" opacity="0.4"/>
+      </g>
+      <text x="40" y="392" fill="#e0f2fe" font-family="'Orbitron', sans-serif" font-size="26" letter-spacing="0.18em">COMET TRENCH</text>
+      <text x="40" y="420" fill="#7dd3fc" font-family="'Rajdhani', sans-serif" font-size="16">Meteor Cascades · Ice Rift Bridges · Antigrav Sling</text>
+    </g>
+
+    <g transform="translate(480 0)">
+      <rect width="440" height="440" rx="30" fill="#140021" stroke="#2d0d3a" stroke-width="3"/>
+      <rect width="440" height="440" rx="30" fill="url(#panelOverlay)" opacity="0.8"/>
+      <g clip-path="url(#clipQuantum)">
+        <defs>
+          <clipPath id="clipQuantum"><rect width="440" height="440" rx="30"/></clipPath>
+          <linearGradient id="quantumHorizon" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#2b0038"/>
+            <stop offset="50%" stop-color="#420053"/>
+            <stop offset="100%" stop-color="#5e0076"/>
+          </linearGradient>
+          <linearGradient id="quantumGround" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#1b0024"/>
+            <stop offset="100%" stop-color="#2d0036"/>
+          </linearGradient>
+          <radialGradient id="quantumBloom" cx="0.5" cy="0.2" r="0.5">
+            <stop offset="0%" stop-color="#f472b6" stop-opacity="0.4"/>
+            <stop offset="100%" stop-color="#f472b6" stop-opacity="0"/>
+          </radialGradient>
+        </defs>
+        <rect width="440" height="440" fill="url(#quantumHorizon)"/>
+        <circle cx="200" cy="120" r="90" fill="url(#quantumBloom)"/>
+        <circle cx="320" cy="140" r="70" fill="url(#quantumBloom)" opacity="0.6"/>
+        <circle cx="120" cy="100" r="50" fill="url(#quantumBloom)" opacity="0.6"/>
+        <path d="M0 280 C100 240 200 220 280 240 C360 260 420 300 440 320 V440 H0 Z" fill="url(#quantumGround)"/>
+        <path d="M0 332 C120 288 220 274 320 288 C380 296 420 314 440 326" fill="none" stroke="#f472b6" stroke-width="6" stroke-linecap="round"/>
+        <path d="M0 344 C120 298 238 288 332 302 C372 308 420 322 440 334" fill="none" stroke="#fbcfe8" stroke-width="4" stroke-linecap="round" stroke-dasharray="16 12" opacity="0.7"/>
+        <g fill="#f472b6" opacity="0.5">
+          <rect x="60" y="170" width="60" height="12" rx="6"/>
+          <rect x="132" y="152" width="72" height="10" rx="5"/>
+          <rect x="214" y="134" width="92" height="10" rx="5"/>
+          <rect x="320" y="148" width="58" height="10" rx="5"/>
+        </g>
+      </g>
+      <text x="40" y="392" fill="#fee2f2" font-family="'Orbitron', sans-serif" font-size="26" letter-spacing="0.18em">QUANTUM BLOOM</text>
+      <text x="40" y="420" fill="#f9a8d4" font-family="'Rajdhani', sans-serif" font-size="16">Floral Nebulae · Bio-Circuit Causeways · Lumina Petals</text>
+    </g>
+
+    <g transform="translate(960 0)">
+      <rect width="440" height="440" rx="30" fill="#1c0600" stroke="#7c2d12" stroke-width="3"/>
+      <rect width="440" height="440" rx="30" fill="url(#panelOverlay)" opacity="0.7"/>
+      <g clip-path="url(#clipUmbra)">
+        <defs>
+          <clipPath id="clipUmbra"><rect width="440" height="440" rx="30"/></clipPath>
+          <linearGradient id="umbraHorizon" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#150008"/>
+            <stop offset="50%" stop-color="#2d0713"/>
+            <stop offset="100%" stop-color="#43111d"/>
+          </linearGradient>
+          <linearGradient id="umbraGround" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#1f0a00"/>
+            <stop offset="100%" stop-color="#33110a"/>
+          </linearGradient>
+          <radialGradient id="umbraGlow" cx="0.6" cy="0.24" r="0.6">
+            <stop offset="0%" stop-color="#facc15" stop-opacity="0.38"/>
+            <stop offset="100%" stop-color="#facc15" stop-opacity="0"/>
+          </radialGradient>
+        </defs>
+        <rect width="440" height="440" fill="url(#umbraHorizon)"/>
+        <circle cx="280" cy="120" r="90" fill="url(#umbraGlow)"/>
+        <circle cx="160" cy="130" r="60" fill="url(#umbraGlow)" opacity="0.55"/>
+        <path d="M0 270 C90 210 190 190 280 210 C340 222 380 250 440 248 V440 H0 Z" fill="url(#umbraGround)"/>
+        <path d="M0 320 C110 276 220 260 320 276 C370 284 410 300 440 312" fill="none" stroke="#facc15" stroke-width="6" stroke-linecap="round"/>
+        <path d="M0 334 C120 288 226 272 320 286 C370 294 410 306 440 318" fill="none" stroke="#fde68a" stroke-width="4" stroke-linecap="round" stroke-dasharray="16 12" opacity="0.7"/>
+        <g fill="#fde68a" opacity="0.45">
+          <rect x="70" y="168" width="60" height="12" rx="6"/>
+          <rect x="152" y="150" width="70" height="10" rx="5"/>
+          <rect x="236" y="140" width="88" height="10" rx="5"/>
+        </g>
+        <path d="M0 360 L80 320 L160 348 L240 308 L320 332 L400 296 L440 320 V440 H0 Z" fill="#1f2937" opacity="0.3"/>
+      </g>
+      <text x="40" y="392" fill="#fef3c7" font-family="'Orbitron', sans-serif" font-size="26" letter-spacing="0.18em">UMBRA EXPANSE</text>
+      <text x="40" y="420" fill="#fde68a" font-family="'Rajdhani', sans-serif" font-size="16">Solar Wreckage · Penumbra Pillars · Ember Fountains</text>
+    </g>
+  </g>
+  <text x="720" y="496" fill="#38bdf8" font-family="'Orbitron', sans-serif" font-size="20" text-anchor="middle" letter-spacing="0.24em">VANGUARD CIRCUIT KEY ART</text>
+</svg>

--- a/assets/sprites/space_glider_pixelart.svg
+++ b/assets/sprites/space_glider_pixelart.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="240" viewBox="0 0 480 240" role="img" aria-labelledby="title desc">
+  <title id="title">Spacer-X Pixel Gliders</title>
+  <desc id="desc">Pixelart-Sheet mit zwei neuen Space-Glider-Konzepten für das Rennspiel.</desc>
+  <defs>
+    <linearGradient id="sheetBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#050915"/>
+      <stop offset="100%" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="480" height="240" rx="24" fill="url(#sheetBg)"/>
+  <g transform="translate(48 36)">
+    <rect x="0" y="0" width="160" height="160" rx="12" fill="#111827" stroke="#1f2937" stroke-width="2"/>
+    <g transform="translate(32 24) scale(2)" shape-rendering="crispEdges">
+      <rect x="16" y="8" width="16" height="4" fill="#38bdf8"/>
+      <rect x="12" y="12" width="24" height="4" fill="#0ea5e9"/>
+      <rect x="8" y="16" width="32" height="4" fill="#0ea5e9"/>
+      <rect x="12" y="20" width="24" height="4" fill="#38bdf8"/>
+      <rect x="18" y="24" width="12" height="12" fill="#1e40af"/>
+      <rect x="20" y="26" width="8" height="8" fill="#38bdf8"/>
+      <rect x="6" y="18" width="4" height="8" fill="#bae6fd"/>
+      <rect x="42" y="18" width="4" height="8" fill="#bae6fd"/>
+      <rect x="0" y="18" width="6" height="4" fill="#0ea5e9"/>
+      <rect x="46" y="18" width="6" height="4" fill="#0ea5e9"/>
+      <rect x="10" y="32" width="28" height="4" fill="#1e3a8a"/>
+      <rect x="16" y="36" width="16" height="4" fill="#0f172a"/>
+      <rect x="18" y="40" width="12" height="4" fill="#111827"/>
+      <rect x="20" y="44" width="8" height="4" fill="#0f172a"/>
+      <rect x="18" y="48" width="12" height="4" fill="#0ea5e9" opacity="0.6"/>
+      <rect x="6" y="32" width="4" height="8" fill="#2dd4bf" opacity="0.7"/>
+      <rect x="42" y="32" width="4" height="8" fill="#2dd4bf" opacity="0.7"/>
+    </g>
+    <text x="80" y="190" fill="#bae6fd" font-family="'Press Start 2P', monospace" font-size="12" text-anchor="middle">AETHER-LANCE</text>
+    <text x="80" y="206" fill="#93c5fd" font-family="'Rajdhani', sans-serif" font-size="12" text-anchor="middle">Boost Grid · Plasma Rudders</text>
+  </g>
+  <g transform="translate(272 36)">
+    <rect x="0" y="0" width="160" height="160" rx="12" fill="#111827" stroke="#1f2937" stroke-width="2"/>
+    <g transform="translate(32 24) scale(2)" shape-rendering="crispEdges">
+      <rect x="18" y="6" width="12" height="4" fill="#fb7185"/>
+      <rect x="14" y="10" width="20" height="4" fill="#f472b6"/>
+      <rect x="10" y="14" width="28" height="4" fill="#db2777"/>
+      <rect x="8" y="18" width="32" height="4" fill="#9d174d"/>
+      <rect x="16" y="22" width="16" height="4" fill="#fee2e2"/>
+      <rect x="12" y="26" width="24" height="6" fill="#f472b6"/>
+      <rect x="20" y="32" width="8" height="8" fill="#be123c"/>
+      <rect x="4" y="20" width="4" height="10" fill="#fecdd3"/>
+      <rect x="40" y="20" width="4" height="10" fill="#fecdd3"/>
+      <rect x="0" y="22" width="4" height="6" fill="#fb7185"/>
+      <rect x="44" y="22" width="4" height="6" fill="#fb7185"/>
+      <rect x="10" y="32" width="8" height="4" fill="#fde68a" opacity="0.7"/>
+      <rect x="34" y="32" width="8" height="4" fill="#fde68a" opacity="0.7"/>
+      <rect x="18" y="40" width="12" height="4" fill="#fbcfe8" opacity="0.8"/>
+      <rect x="14" y="44" width="20" height="4" fill="#831843" opacity="0.8"/>
+      <rect x="18" y="48" width="12" height="4" fill="#9d174d" opacity="0.9"/>
+      <rect x="20" y="52" width="8" height="6" fill="#f472b6"/>
+    </g>
+    <text x="80" y="190" fill="#f9a8d4" font-family="'Press Start 2P', monospace" font-size="12" text-anchor="middle">VIOLET-FLARE</text>
+    <text x="80" y="206" fill="#fbcfe8" font-family="'Rajdhani', sans-serif" font-size="12" text-anchor="middle">Flux Vectoring · Echo Vanes</text>
+  </g>
+</svg>

--- a/assets/sprites/space_glider_pixelart_set2.svg
+++ b/assets/sprites/space_glider_pixelart_set2.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="280" viewBox="0 0 640 280" role="img" aria-labelledby="title desc">
+  <title id="title">Spacer-X Pixel Gliders – Vanguard Set</title>
+  <desc id="desc">Pixelart-Sheet mit drei neuen Space-Glidern: Prism Rider, Eclipse Talon und Grav Seraph.</desc>
+  <defs>
+    <linearGradient id="sheetBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#040712"/>
+      <stop offset="100%" stop-color="#0b1224"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="280" rx="28" fill="url(#sheetBg)"/>
+  <g transform="translate(48 44)">
+    <rect x="0" y="0" width="160" height="168" rx="16" fill="#0f172a" stroke="#1f2937" stroke-width="2"/>
+    <g transform="translate(24 20) scale(2)" shape-rendering="crispEdges">
+      <rect x="16" y="0" width="16" height="4" fill="#22d3ee"/>
+      <rect x="12" y="4" width="24" height="4" fill="#0ea5e9"/>
+      <rect x="8" y="8" width="32" height="4" fill="#2563eb"/>
+      <rect x="4" y="12" width="40" height="4" fill="#1d4ed8"/>
+      <rect x="0" y="16" width="48" height="4" fill="#1e3a8a"/>
+      <rect x="6" y="20" width="36" height="4" fill="#312e81"/>
+      <rect x="12" y="24" width="24" height="6" fill="#38bdf8"/>
+      <rect x="18" y="30" width="12" height="8" fill="#0f172a"/>
+      <rect x="18" y="38" width="12" height="4" fill="#38bdf8"/>
+      <rect x="6" y="26" width="6" height="10" fill="#67e8f9"/>
+      <rect x="36" y="26" width="6" height="10" fill="#67e8f9"/>
+      <rect x="4" y="14" width="4" height="8" fill="#38bdf8" opacity="0.8"/>
+      <rect x="40" y="14" width="4" height="8" fill="#38bdf8" opacity="0.8"/>
+      <rect x="18" y="42" width="12" height="6" fill="#172554"/>
+      <rect x="20" y="48" width="8" height="6" fill="#0ea5e9"/>
+      <rect x="10" y="34" width="6" height="4" fill="#1d4ed8"/>
+      <rect x="32" y="34" width="6" height="4" fill="#1d4ed8"/>
+    </g>
+    <text x="80" y="190" fill="#bfdbfe" font-family="'Press Start 2P', monospace" font-size="12" text-anchor="middle">PRISM RIDER</text>
+    <text x="80" y="208" fill="#93c5fd" font-family="'Rajdhani', sans-serif" font-size="12" text-anchor="middle">Photon Spoilers · Facet Intake</text>
+  </g>
+
+  <g transform="translate(240 44)">
+    <rect x="0" y="0" width="160" height="168" rx="16" fill="#111827" stroke="#1f2937" stroke-width="2"/>
+    <g transform="translate(24 20) scale(2)" shape-rendering="crispEdges">
+      <rect x="18" y="2" width="12" height="4" fill="#f472b6"/>
+      <rect x="12" y="6" width="24" height="4" fill="#fb7185"/>
+      <rect x="8" y="10" width="32" height="4" fill="#be123c"/>
+      <rect x="4" y="14" width="40" height="4" fill="#831843"/>
+      <rect x="0" y="18" width="48" height="4" fill="#4c0519"/>
+      <rect x="10" y="22" width="28" height="4" fill="#fda4af"/>
+      <rect x="18" y="26" width="12" height="6" fill="#fef2f2"/>
+      <rect x="6" y="22" width="4" height="12" fill="#fca5a5"/>
+      <rect x="38" y="22" width="4" height="12" fill="#fca5a5"/>
+      <rect x="12" y="30" width="24" height="4" fill="#fb7185"/>
+      <rect x="10" y="34" width="28" height="4" fill="#450a0a"/>
+      <rect x="18" y="38" width="12" height="6" fill="#f472b6"/>
+      <rect x="18" y="44" width="12" height="4" fill="#111827"/>
+      <rect x="20" y="48" width="8" height="6" fill="#fb7185" opacity="0.9"/>
+      <rect x="8" y="26" width="6" height="6" fill="#fef3f4" opacity="0.8"/>
+      <rect x="34" y="26" width="6" height="6" fill="#fef3f4" opacity="0.8"/>
+    </g>
+    <text x="80" y="190" fill="#f9a8d4" font-family="'Press Start 2P', monospace" font-size="12" text-anchor="middle">ECLIPSE TALON</text>
+    <text x="80" y="208" fill="#fbcfe8" font-family="'Rajdhani', sans-serif" font-size="12" text-anchor="middle">Nightfall Ram · Ion Blade</text>
+  </g>
+
+  <g transform="translate(432 44)">
+    <rect x="0" y="0" width="160" height="168" rx="16" fill="#0f172a" stroke="#1f2937" stroke-width="2"/>
+    <g transform="translate(24 20) scale(2)" shape-rendering="crispEdges">
+      <rect x="20" y="0" width="8" height="4" fill="#fde68a"/>
+      <rect x="14" y="4" width="20" height="4" fill="#facc15"/>
+      <rect x="10" y="8" width="28" height="4" fill="#d97706"/>
+      <rect x="6" y="12" width="36" height="4" fill="#b45309"/>
+      <rect x="2" y="16" width="44" height="4" fill="#92400e"/>
+      <rect x="0" y="20" width="48" height="4" fill="#78350f"/>
+      <rect x="8" y="24" width="32" height="4" fill="#facc15"/>
+      <rect x="14" y="28" width="20" height="4" fill="#fef3c7"/>
+      <rect x="18" y="32" width="12" height="8" fill="#f8fafc"/>
+      <rect x="6" y="26" width="6" height="8" fill="#fde68a" opacity="0.75"/>
+      <rect x="36" y="26" width="6" height="8" fill="#fde68a" opacity="0.75"/>
+      <rect x="10" y="36" width="28" height="4" fill="#451a03"/>
+      <rect x="18" y="40" width="12" height="6" fill="#78350f"/>
+      <rect x="20" y="46" width="8" height="6" fill="#facc15"/>
+      <rect x="14" y="18" width="20" height="4" fill="#f59e0b" opacity="0.8"/>
+    </g>
+    <text x="80" y="190" fill="#fde68a" font-family="'Press Start 2P', monospace" font-size="12" text-anchor="middle">GRAV SERAPH</text>
+    <text x="80" y="208" fill="#fef3c7" font-family="'Rajdhani', sans-serif" font-size="12" text-anchor="middle">Sunline Dihedral · Halo Thrusters</text>
+  </g>
+</svg>

--- a/assets/sprites/space_glider_pixelart_set3.svg
+++ b/assets/sprites/space_glider_pixelart_set3.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="340" viewBox="0 0 920 340" role="img" aria-labelledby="title desc">
+  <title id="title">Spacer-X Vanguard Pixelart – Set 03</title>
+  <desc id="desc">Pixelart-Sheet mit den neuen Space-Glidern: Zenith Wyvern, Halo Riptide und Comet Barricade.</desc>
+  <defs>
+    <linearGradient id="panelGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="100%" stop-color="#0f172a"/>
+    </linearGradient>
+    <pattern id="scanlines" x="0" y="0" width="4" height="4" patternUnits="userSpaceOnUse">
+      <rect width="4" height="4" fill="#000" opacity="0.15"/>
+      <rect y="2" width="4" height="2" fill="#38bdf8" opacity="0.08"/>
+    </pattern>
+    <style>
+      text { font-family: 'Share Tech Mono', 'Roboto Mono', monospace; }
+    </style>
+  </defs>
+
+  <rect width="920" height="340" fill="url(#panelGradient)"/>
+  <rect width="920" height="340" fill="url(#scanlines)" opacity="0.45"/>
+  <rect x="32" y="32" width="856" height="276" rx="22" fill="#0b1220" stroke="#38bdf8" stroke-width="3" opacity="0.9"/>
+
+  <g transform="translate(64 64)">
+    <rect width="240" height="224" rx="20" fill="#111c34" stroke="#38bdf8" stroke-width="2"/>
+    <text x="20" y="36" fill="#38bdf8" font-size="18" letter-spacing="0.25em">ZENITH WYVERN</text>
+    <text x="20" y="60" fill="#bae6fd" font-size="12">Hybrid Arc-Wing · Stadium Sprint</text>
+    <g transform="translate(44 84)">
+      <rect x="0" y="46" width="152" height="28" rx="10" fill="#1e3a8a"/>
+      <polygon points="76,0 116,28 76,56 36,28" fill="#60a5fa"/>
+      <polygon points="76,8 110,30 76,52 42,30" fill="#1d4ed8"/>
+      <rect x="22" y="22" width="108" height="12" fill="#0f172a"/>
+      <rect x="30" y="28" width="92" height="6" fill="#38bdf8"/>
+      <rect x="52" y="12" width="48" height="8" fill="#bae6fd"/>
+      <rect x="52" y="44" width="48" height="8" fill="#bae6fd"/>
+      <circle cx="24" cy="30" r="6" fill="#bae6fd"/>
+      <circle cx="128" cy="30" r="6" fill="#bae6fd"/>
+    </g>
+    <text x="20" y="206" fill="#7dd3fc" font-size="11">Callouts:</text>
+    <text x="20" y="222" fill="#7dd3fc" font-size="11">Spectra Rudder · Aurora Stabilizer · Vaulted Canards</text>
+  </g>
+
+  <g transform="translate(336 64)">
+    <rect width="240" height="224" rx="20" fill="#130b1f" stroke="#a855f7" stroke-width="2"/>
+    <text x="20" y="36" fill="#c084fc" font-size="18" letter-spacing="0.24em">HALO RIPTIDE</text>
+    <text x="20" y="60" fill="#f0abfc" font-size="12">Amphib Orbit Skimmer · Surge Defense</text>
+    <g transform="translate(44 84)">
+      <rect x="-2" y="54" width="156" height="22" rx="10" fill="#4c1d95"/>
+      <polygon points="78,0 122,38 78,64 34,38" fill="#a855f7"/>
+      <polygon points="78,12 114,38 78,58 42,38" fill="#6d28d9"/>
+      <rect x="26" y="28" width="104" height="10" fill="#0f172a"/>
+      <rect x="36" y="32" width="84" height="6" fill="#c084fc"/>
+      <rect x="56" y="14" width="44" height="8" fill="#f5f3ff"/>
+      <rect x="56" y="46" width="44" height="8" fill="#f5f3ff"/>
+      <circle cx="28" cy="36" r="6" fill="#f5f3ff"/>
+      <circle cx="128" cy="36" r="6" fill="#f5f3ff"/>
+    </g>
+    <text x="20" y="206" fill="#d8b4fe" font-size="11">Callouts:</text>
+    <text x="20" y="222" fill="#d8b4fe" font-size="11">Flux Fins · Riptide Echo Pods · Tidal Scoop Intake</text>
+  </g>
+
+  <g transform="translate(608 64)">
+    <rect width="240" height="224" rx="20" fill="#160b0f" stroke="#f97316" stroke-width="2"/>
+    <text x="20" y="36" fill="#fb923c" font-size="18" letter-spacing="0.28em">COMET BARRICADE</text>
+    <text x="20" y="60" fill="#fed7aa" font-size="12">Shield Runner · Hazard Rally Pack</text>
+    <g transform="translate(44 84)">
+      <rect x="-4" y="50" width="160" height="26" rx="12" fill="#9a3412"/>
+      <polygon points="80,0 124,34 80,68 36,34" fill="#fb923c"/>
+      <polygon points="80,14 114,34 80,60 46,34" fill="#f97316"/>
+      <rect x="30" y="30" width="100" height="12" fill="#2d1607"/>
+      <rect x="40" y="34" width="80" height="6" fill="#fed7aa"/>
+      <rect x="58" y="16" width="44" height="8" fill="#fed7aa"/>
+      <rect x="58" y="48" width="44" height="8" fill="#fed7aa"/>
+      <circle cx="32" cy="38" r="6" fill="#fed7aa"/>
+      <circle cx="128" cy="38" r="6" fill="#fed7aa"/>
+    </g>
+    <text x="20" y="206" fill="#fdba74" font-size="11">Callouts:</text>
+    <text x="20" y="222" fill="#fdba74" font-size="11">Meteor Shield Array · Kinetic Ramps · Ember Thrusters</text>
+  </g>
+</svg>

--- a/assets/sprites/team_crests.svg
+++ b/assets/sprites/team_crests.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="440" viewBox="0 0 960 440" role="img" aria-labelledby="title desc">
+  <title id="title">Spacer-X Team Crests Collection</title>
+  <desc id="desc">Sechs Wappen-Designs für die Rennteams von Spacer-X mit Neon-Rand, Heraldik-Icons und Farbvarianten.</desc>
+  <defs>
+    <linearGradient id="panelBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="100%" stop-color="#0b1120"/>
+    </linearGradient>
+    <pattern id="grid" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+      <rect width="16" height="16" fill="none"/>
+      <path d="M0 0H16M0 8H16M0 16H16" stroke="#1e293b" stroke-width="1" opacity="0.35"/>
+      <path d="M0 0V16M8 0V16M16 0V16" stroke="#1e293b" stroke-width="1" opacity="0.35"/>
+    </pattern>
+    <linearGradient id="crestGlow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#a855f7" stop-opacity="0.25"/>
+    </linearGradient>
+    <style>
+      text { font-family: 'Orbitron', 'Rajdhani', sans-serif; }
+    </style>
+  </defs>
+
+  <rect width="960" height="440" fill="url(#panelBg)"/>
+  <rect width="960" height="440" fill="url(#grid)" opacity="0.35"/>
+  <rect x="32" y="32" width="896" height="376" rx="28" fill="#0b1220" stroke="#38bdf8" stroke-width="3" opacity="0.9"/>
+  <text x="64" y="92" fill="#38bdf8" font-size="30" letter-spacing="0.32em">TEAM CRESTS</text>
+  <text x="64" y="122" fill="#cbd5f5" font-family="'Rajdhani', sans-serif" font-size="18" opacity="0.75">Heraldik-Icons · Rivalry Highlights · Branding Hooks</text>
+
+  <g transform="translate(64 148)" fill="none" stroke-linejoin="round" stroke-width="4">
+    <g transform="translate(0 0)">
+      <path d="M0 0H160V180L80 212L0 180Z" fill="#0f172a" stroke="#38bdf8"/>
+      <path d="M20 24H140V164L80 188L20 164Z" fill="#111c34" stroke="#38bdf8" opacity="0.85"/>
+      <path d="M60 48L80 16L100 48V120C100 128 92 144 80 152C68 144 60 128 60 120Z" fill="#0ea5e9" stroke="#7dd3fc"/>
+      <circle cx="80" cy="64" r="16" fill="#111827" stroke="#38bdf8" stroke-width="3"/>
+      <path d="M72 64L80 52L88 64L80 76Z" fill="#38bdf8"/>
+      <text x="80" y="208" fill="#e0f2fe" font-size="16" text-anchor="middle">AURORA WARDENS</text>
+    </g>
+
+    <g transform="translate(200 0)">
+      <path d="M0 0H160V180L80 212L0 180Z" fill="#130b1f" stroke="#a855f7"/>
+      <path d="M20 24H140V164L80 188L20 164Z" fill="#1f1130" stroke="#a855f7" opacity="0.85"/>
+      <path d="M52 48L108 48L134 90L108 132H52L26 90Z" fill="#a855f7" stroke="#d8b4fe"/>
+      <path d="M64 68L96 68L110 90L96 112H64L50 90Z" fill="#581c87"/>
+      <path d="M80 46L92 32L108 42L112 60L94 54L80 62L66 54L48 60L52 42L68 32Z" fill="#f0abfc" opacity="0.8"/>
+      <text x="80" y="208" fill="#f5f3ff" font-size="16" text-anchor="middle">NOVA PALADINS</text>
+    </g>
+
+    <g transform="translate(400 0)">
+      <path d="M0 0H160V180L80 212L0 180Z" fill="#0f172a" stroke="#f97316"/>
+      <path d="M20 24H140V164L80 188L20 164Z" fill="#17120d" stroke="#f97316" opacity="0.85"/>
+      <path d="M40 60H120L140 96L120 132H40L20 96Z" fill="#fb923c" stroke="#fed7aa"/>
+      <path d="M56 80H104L116 96L104 112H56L44 96Z" fill="#9a3412"/>
+      <path d="M80 38L96 64L132 72L106 94L112 128L80 110L48 128L54 94L28 72L64 64Z" fill="#f97316"/>
+      <text x="80" y="208" fill="#fed7aa" font-size="16" text-anchor="middle">EMBER VANGUARD</text>
+    </g>
+
+    <g transform="translate(0 212)">
+      <path d="M0 0H160V180L80 212L0 180Z" fill="#041f1f" stroke="#2dd4bf"/>
+      <path d="M20 24H140V164L80 188L20 164Z" fill="#052e2e" stroke="#2dd4bf" opacity="0.85"/>
+      <path d="M48 52L80 26L112 52V128L80 152L48 128Z" fill="#0f766e" stroke="#5eead4"/>
+      <path d="M64 78L80 62L96 78V108L80 122L64 108Z" fill="#134e4a"/>
+      <path d="M40 132H120V148H40Z" fill="#14b8a6" opacity="0.75"/>
+      <text x="80" y="208" fill="#a7f3d0" font-size="16" text-anchor="middle">TIDAL ORACLE</text>
+    </g>
+
+    <g transform="translate(200 212)">
+      <path d="M0 0H160V180L80 212L0 180Z" fill="#1b1121" stroke="#ec4899"/>
+      <path d="M20 24H140V164L80 188L20 164Z" fill="#240c1f" stroke="#ec4899" opacity="0.85"/>
+      <path d="M48 60L80 32L112 60V124L80 152L48 124Z" fill="#ec4899" stroke="#f472b6"/>
+      <circle cx="80" cy="92" r="24" fill="#f472b6" stroke="#fbcfe8" stroke-width="3"/>
+      <path d="M80 70L90 92L80 114L70 92Z" fill="#be185d"/>
+      <path d="M56 130H104V150H56Z" fill="#fda4af" opacity="0.75"/>
+      <text x="80" y="208" fill="#fce7f3" font-size="16" text-anchor="middle">PRISM LILITH</text>
+    </g>
+
+    <g transform="translate(400 212)">
+      <path d="M0 0H160V180L80 212L0 180Z" fill="#1e1b4b" stroke="#4ade80"/>
+      <path d="M20 24H140V164L80 188L20 164Z" fill="#111827" stroke="#4ade80" opacity="0.85"/>
+      <path d="M32 68H128L144 92L128 116H32L16 92Z" fill="#22c55e" stroke="#86efac"/>
+      <path d="M52 88H108L118 100L108 112H52L42 100Z" fill="#0f172a"/>
+      <path d="M80 38L104 56L120 46L128 66L110 70L120 92L96 82L80 104L64 82L40 92L50 70L32 66L40 46L56 56Z" fill="#4ade80"/>
+      <text x="80" y="208" fill="#bbf7d0" font-size="16" text-anchor="middle">GREENLINE RALLY</text>
+    </g>
+  </g>
+</svg>

--- a/assets/sprites/track_concepts.svg
+++ b/assets/sprites/track_concepts.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1320" height="360" viewBox="0 0 1320 360" role="img" aria-labelledby="title desc">
+  <title id="title">Spacer-X Track Concept Posters</title>
+  <desc id="desc">Drei neue Rennstrecken-Konzepte mit Farbwelten und Top-Down Layoutlinien.</desc>
+  <defs>
+    <linearGradient id="auroraSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#081226"/>
+      <stop offset="100%" stop-color="#1b9aaa"/>
+    </linearGradient>
+    <linearGradient id="auroraRim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38f9d7" stop-opacity="0"/>
+      <stop offset="45%" stop-color="#38f9d7" stop-opacity="0.75"/>
+      <stop offset="100%" stop-color="#4f46e5" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="ionSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#230045"/>
+      <stop offset="100%" stop-color="#a855f7"/>
+    </linearGradient>
+    <linearGradient id="ionRim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#fda4af" stop-opacity="0"/>
+      <stop offset="35%" stop-color="#fb7185" stop-opacity="0.75"/>
+      <stop offset="100%" stop-color="#be123c" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="solarSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#150614"/>
+      <stop offset="100%" stop-color="#f97316"/>
+    </linearGradient>
+    <linearGradient id="solarRim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#fde68a" stop-opacity="0"/>
+      <stop offset="40%" stop-color="#facc15" stop-opacity="0.75"/>
+      <stop offset="100%" stop-color="#fb923c" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="focalGlow" cx="0.5" cy="0.35" r="0.65">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.16"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <g transform="translate(40 40)">
+    <rect width="360" height="280" rx="24" fill="url(#auroraSky)"/>
+    <rect width="360" height="280" rx="24" fill="url(#auroraRim)" opacity="0.7"/>
+    <rect x="24" y="32" width="312" height="216" rx="18" fill="url(#focalGlow)" opacity="0.35"/>
+    <g fill="none" stroke="#5eead4" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M60 220 C120 120 120 80 180 90 S260 150 304 110" opacity="0.8"/>
+      <path d="M88 214 Q134 160 174 146 T260 150" stroke-dasharray="10 8" opacity="0.6"/>
+      <circle cx="180" cy="90" r="8" fill="#22d3ee"/>
+      <circle cx="304" cy="110" r="8" fill="#22d3ee"/>
+    </g>
+    <text x="36" y="82" fill="#a5f3fc" font-family="'Orbitron', sans-serif" font-size="30" letter-spacing="0.22em">AURORA</text>
+    <text x="36" y="120" fill="#bae6fd" font-family="'Orbitron', sans-serif" font-size="22" letter-spacing="0.32em">SKYWAY</text>
+    <text x="36" y="152" fill="#cffafe" font-family="'Rajdhani', sans-serif" font-size="14" opacity="0.8">Polar Lumen Fields · Antigrav Jets · Split Stream Sectors</text>
+  </g>
+  <g transform="translate(480 40)">
+    <rect width="360" height="280" rx="24" fill="url(#ionSky)"/>
+    <rect width="360" height="280" rx="24" fill="url(#ionRim)" opacity="0.65"/>
+    <rect x="24" y="32" width="312" height="216" rx="18" fill="#ffffff" opacity="0.08"/>
+    <g fill="none" stroke="#f9a8d4" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M72 224 C112 140 188 140 232 96 S310 112 308 202" opacity="0.85"/>
+      <path d="M96 214 C148 168 196 168 242 130" stroke-dasharray="12 10" opacity="0.6"/>
+      <circle cx="232" cy="96" r="8" fill="#f472b6"/>
+      <circle cx="308" cy="202" r="8" fill="#f472b6"/>
+    </g>
+    <text x="36" y="82" fill="#fdf2f8" font-family="'Orbitron', sans-serif" font-size="30" letter-spacing="0.18em">ION</text>
+    <text x="36" y="120" fill="#fbcfe8" font-family="'Orbitron', sans-serif" font-size="22" letter-spacing="0.34em">SPINE</text>
+    <text x="36" y="152" fill="#fecdd3" font-family="'Rajdhani', sans-serif" font-size="14" opacity="0.8">Bio-Lum Overpass · Flux Gates · Double Helix Drop</text>
+  </g>
+  <g transform="translate(920 40)">
+    <rect width="360" height="280" rx="24" fill="url(#solarSky)"/>
+    <rect width="360" height="280" rx="24" fill="url(#solarRim)" opacity="0.7"/>
+    <rect x="24" y="32" width="312" height="216" rx="18" fill="#ffffff" opacity="0.05"/>
+    <g fill="none" stroke="#fde68a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M70 210 C100 140 150 110 202 130 S290 190 310 236" opacity="0.9"/>
+      <path d="M102 200 C142 158 190 142 230 162 T292 210" stroke-dasharray="10 8" opacity="0.6"/>
+      <circle cx="202" cy="130" r="8" fill="#facc15"/>
+      <circle cx="310" cy="236" r="8" fill="#facc15"/>
+    </g>
+    <text x="36" y="82" fill="#fff7ed" font-family="'Orbitron', sans-serif" font-size="30" letter-spacing="0.2em">SOLAR</text>
+    <text x="36" y="120" fill="#ffedd5" font-family="'Orbitron', sans-serif" font-size="22" letter-spacing="0.32em">CASCADE</text>
+    <text x="36" y="152" fill="#fed7aa" font-family="'Rajdhani', sans-serif" font-size="14" opacity="0.8">Heliostat Arches · Lavafall Sprint · Superheated Apex</text>
+  </g>
+</svg>

--- a/assets/sprites/track_concepts_set2.svg
+++ b/assets/sprites/track_concepts_set2.svg
@@ -1,0 +1,123 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1320" height="400" viewBox="0 0 1320 400" role="img" aria-labelledby="title desc">
+  <title id="title">Spacer-X Panorama Track Concepts – Set 02</title>
+  <desc id="desc">Triptychon mit neuen Rennstrecken-Konzepten: Comet Trench, Quantum Bloom und Umbra Expanse.</desc>
+  <defs>
+    <linearGradient id="cometGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#010b1a"/>
+      <stop offset="50%" stop-color="#092646"/>
+      <stop offset="100%" stop-color="#133c73"/>
+    </linearGradient>
+    <linearGradient id="cometRim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0"/>
+      <stop offset="40%" stop-color="#38bdf8" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="cometGlow" cx="0.62" cy="0.24" r="0.68">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
+    </radialGradient>
+
+    <linearGradient id="quantumGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#220029"/>
+      <stop offset="50%" stop-color="#320047"/>
+      <stop offset="100%" stop-color="#54007a"/>
+    </linearGradient>
+    <linearGradient id="quantumRim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#fb7185" stop-opacity="0"/>
+      <stop offset="42%" stop-color="#fb7185" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="quantumBloom" cx="0.45" cy="0.2" r="0.72">
+      <stop offset="0%" stop-color="#fbcfe8" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#fbcfe8" stop-opacity="0"/>
+    </radialGradient>
+
+    <linearGradient id="umbraGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#050007"/>
+      <stop offset="50%" stop-color="#120016"/>
+      <stop offset="100%" stop-color="#2c0b1e"/>
+    </linearGradient>
+    <linearGradient id="umbraRim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#facc15" stop-opacity="0"/>
+      <stop offset="45%" stop-color="#facc15" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#facc15" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="umbraGlow" cx="0.55" cy="0.28" r="0.78">
+      <stop offset="0%" stop-color="#fed7aa" stop-opacity="0.24"/>
+      <stop offset="100%" stop-color="#fed7aa" stop-opacity="0"/>
+    </radialGradient>
+
+    <pattern id="starfield" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <rect width="20" height="20" fill="none"/>
+      <circle cx="3" cy="6" r="1.2" fill="#ffffff" opacity="0.4"/>
+      <circle cx="12" cy="2" r="1.4" fill="#38bdf8" opacity="0.5"/>
+      <circle cx="16" cy="14" r="1.6" fill="#f9a8d4" opacity="0.5"/>
+    </pattern>
+  </defs>
+
+  <rect x="0" y="0" width="1320" height="400" fill="#010409"/>
+  <rect x="0" y="0" width="1320" height="400" fill="url(#starfield)" opacity="0.35"/>
+  <g transform="translate(40 48)">
+    <rect width="360" height="304" rx="28" fill="url(#cometGradient)"/>
+    <rect width="360" height="304" rx="28" fill="url(#cometRim)" opacity="0.8"/>
+    <rect x="26" y="34" width="308" height="216" rx="18" fill="url(#cometGlow)"/>
+    <g fill="none" stroke="#67e8f9" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M58 256 C78 176 152 134 218 148 C272 162 308 210 306 260" opacity="0.85"/>
+      <path d="M80 246 C110 188 172 162 224 176 C258 186 286 214 294 244" stroke-dasharray="12 9" opacity="0.6"/>
+      <circle cx="218" cy="148" r="9" fill="#38bdf8"/>
+      <circle cx="306" cy="260" r="9" fill="#38bdf8"/>
+    </g>
+    <g fill="#0ea5e9" opacity="0.5">
+      <rect x="60" y="88" width="44" height="6" rx="3"/>
+      <rect x="108" y="76" width="58" height="8" rx="4"/>
+      <rect x="180" y="70" width="76" height="10" rx="5"/>
+    </g>
+    <text x="36" y="90" fill="#e0f2fe" font-family="'Orbitron', sans-serif" font-size="30" letter-spacing="0.28em">COMET</text>
+    <text x="36" y="128" fill="#bae6fd" font-family="'Orbitron', sans-serif" font-size="22" letter-spacing="0.32em">TRENCH</text>
+    <text x="36" y="160" fill="#bae6fd" font-family="'Rajdhani', sans-serif" font-size="16" opacity="0.9">Grav-Schleusen · Plasma-Schluchten · Meteor Drift-Lanes</text>
+    <text x="36" y="186" fill="#7dd3fc" font-family="'Rajdhani', sans-serif" font-size="14" opacity="0.8">Crew Callouts: Helix Boost Gate · Cryo Shear Cavern · Horizon Sling</text>
+  </g>
+
+  <g transform="translate(480 48)">
+    <rect width="360" height="304" rx="28" fill="url(#quantumGradient)"/>
+    <rect width="360" height="304" rx="28" fill="url(#quantumRim)" opacity="0.75"/>
+    <rect x="26" y="34" width="308" height="216" rx="18" fill="url(#quantumBloom)"/>
+    <g fill="none" stroke="#f472b6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M62 252 C96 182 156 152 214 132 C268 112 312 138 310 202 C308 266 272 304 214 302 C156 300 110 280 90 252" opacity="0.9"/>
+      <path d="M84 240 C118 190 172 162 224 148 C266 136 296 154 298 196" stroke-dasharray="14 10" opacity="0.6"/>
+      <circle cx="214" cy="132" r="9" fill="#f472b6"/>
+      <circle cx="310" cy="202" r="9" fill="#f472b6"/>
+    </g>
+    <g fill="#f9a8d4" opacity="0.45">
+      <circle cx="92" cy="96" r="12"/>
+      <circle cx="150" cy="78" r="16"/>
+      <circle cx="224" cy="70" r="18"/>
+      <circle cx="276" cy="88" r="12"/>
+    </g>
+    <text x="36" y="90" fill="#fee2e2" font-family="'Orbitron', sans-serif" font-size="30" letter-spacing="0.24em">QUANTUM</text>
+    <text x="36" y="128" fill="#fbcfe8" font-family="'Orbitron', sans-serif" font-size="22" letter-spacing="0.34em">BLOOM</text>
+    <text x="36" y="160" fill="#fbcfe8" font-family="'Rajdhani', sans-serif" font-size="16" opacity="0.9">Florale Schwerkraftgärten · Flux-Pod-Brücken · Spiral-Canopy</text>
+    <text x="36" y="186" fill="#f9a8d4" font-family="'Rajdhani', sans-serif" font-size="14" opacity="0.8">Crew Callouts: Blossom Slipstream · Mycelium Coil · Prism Lattice</text>
+  </g>
+
+  <g transform="translate(920 48)">
+    <rect width="360" height="304" rx="28" fill="url(#umbraGradient)"/>
+    <rect width="360" height="304" rx="28" fill="url(#umbraRim)" opacity="0.78"/>
+    <rect x="26" y="34" width="308" height="216" rx="18" fill="url(#umbraGlow)"/>
+    <g fill="none" stroke="#facc15" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M64 254 C96 172 164 118 230 132 C284 144 316 206 302 270 C288 334 230 338 176 320 C122 302 84 272 76 250" opacity="0.92"/>
+      <path d="M90 238 C124 178 178 138 228 146 C268 152 294 194 286 238" stroke-dasharray="12 10" opacity="0.65"/>
+      <circle cx="230" cy="132" r="9" fill="#facc15"/>
+      <circle cx="302" cy="270" r="9" fill="#facc15"/>
+    </g>
+    <g fill="#fde68a" opacity="0.4">
+      <rect x="78" y="84" width="52" height="10" rx="4"/>
+      <rect x="146" y="70" width="60" height="12" rx="6"/>
+      <rect x="220" y="82" width="70" height="10" rx="5"/>
+    </g>
+    <text x="36" y="90" fill="#fffbeb" font-family="'Orbitron', sans-serif" font-size="30" letter-spacing="0.26em">UMBRA</text>
+    <text x="36" y="128" fill="#fef3c7" font-family="'Orbitron', sans-serif" font-size="22" letter-spacing="0.3em">EXPANSE</text>
+    <text x="36" y="160" fill="#fef3c7" font-family="'Rajdhani', sans-serif" font-size="16" opacity="0.9">Eclipse-Wracks · Titan-Säulen · Dämmerungs-Schlieren</text>
+    <text x="36" y="186" fill="#fde68a" font-family="'Rajdhani', sans-serif" font-size="14" opacity="0.8">Crew Callouts: Noctilucent Basin · Penumbra Gate · Solar Wake</text>
+  </g>
+</svg>

--- a/assets/sprites/track_concepts_set3.svg
+++ b/assets/sprites/track_concepts_set3.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1320" height="400" viewBox="0 0 1320 400" role="img" aria-labelledby="title desc">
+  <title id="title">Spacer-X Panorama Track Concepts – Set 03</title>
+  <desc id="desc">Triptychon mit neuen Stadien-Strecken: Luminaria Circuit, Ion Velodrome und Parallax Forum.</desc>
+  <defs>
+    <linearGradient id="luminariaGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="45%" stop-color="#0b1440"/>
+      <stop offset="100%" stop-color="#132868"/>
+    </linearGradient>
+    <linearGradient id="luminariaRim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0"/>
+      <stop offset="48%" stop-color="#38bdf8" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="luminariaGlow" cx="0.5" cy="0.32" r="0.68">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
+    </radialGradient>
+
+    <linearGradient id="ionGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#15000f"/>
+      <stop offset="45%" stop-color="#310029"/>
+      <stop offset="100%" stop-color="#4d0046"/>
+    </linearGradient>
+    <linearGradient id="ionRim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#a855f7" stop-opacity="0"/>
+      <stop offset="46%" stop-color="#a855f7" stop-opacity="0.82"/>
+      <stop offset="100%" stop-color="#a855f7" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="ionGlow" cx="0.5" cy="0.32" r="0.7">
+      <stop offset="0%" stop-color="#f0abfc" stop-opacity="0.28"/>
+      <stop offset="100%" stop-color="#f0abfc" stop-opacity="0"/>
+    </radialGradient>
+
+    <linearGradient id="forumGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#000514"/>
+      <stop offset="45%" stop-color="#04172f"/>
+      <stop offset="100%" stop-color="#0f2746"/>
+    </linearGradient>
+    <linearGradient id="forumRim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f97316" stop-opacity="0"/>
+      <stop offset="44%" stop-color="#f97316" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#f97316" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="forumGlow" cx="0.5" cy="0.34" r="0.72">
+      <stop offset="0%" stop-color="#fdba74" stop-opacity="0.28"/>
+      <stop offset="100%" stop-color="#fdba74" stop-opacity="0"/>
+    </radialGradient>
+
+    <pattern id="stadiumStars" x="0" y="0" width="22" height="22" patternUnits="userSpaceOnUse">
+      <rect width="22" height="22" fill="none"/>
+      <circle cx="4" cy="6" r="1.1" fill="#f8fafc" opacity="0.35"/>
+      <circle cx="14" cy="2" r="1.5" fill="#38bdf8" opacity="0.4"/>
+      <circle cx="18" cy="16" r="1.3" fill="#f472b6" opacity="0.45"/>
+      <circle cx="8" cy="18" r="1" fill="#fde68a" opacity="0.45"/>
+    </pattern>
+  </defs>
+
+  <rect width="1320" height="400" fill="#010409"/>
+  <rect width="1320" height="400" fill="url(#stadiumStars)" opacity="0.35"/>
+
+  <g transform="translate(40 48)">
+    <rect width="360" height="304" rx="28" fill="url(#luminariaGradient)"/>
+    <rect width="360" height="304" rx="28" fill="url(#luminariaRim)" opacity="0.8"/>
+    <rect x="26" y="32" width="308" height="220" rx="18" fill="url(#luminariaGlow)"/>
+    <g fill="#0ea5e9" opacity="0.45">
+      <rect x="44" y="70" width="64" height="10" rx="5"/>
+      <rect x="118" y="60" width="72" height="12" rx="6"/>
+      <rect x="204" y="66" width="82" height="10" rx="5"/>
+    </g>
+    <g fill="none" stroke="#38bdf8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M66 250 C90 190 148 160 210 166 C260 172 298 206 304 250" opacity="0.9"/>
+      <path d="M82 240 C116 186 176 156 224 166 C266 176 292 204 292 236" stroke-dasharray="14 10" opacity="0.65"/>
+      <circle cx="210" cy="166" r="9" fill="#38bdf8"/>
+      <circle cx="304" cy="250" r="9" fill="#38bdf8"/>
+    </g>
+    <g fill="#38bdf8" opacity="0.55">
+      <rect x="50" y="216" width="36" height="12" rx="6"/>
+      <rect x="102" y="226" width="42" height="12" rx="6"/>
+      <rect x="154" y="214" width="40" height="12" rx="6"/>
+      <rect x="240" y="228" width="48" height="12" rx="6"/>
+    </g>
+    <text x="36" y="96" fill="#e0f2fe" font-family="'Orbitron', sans-serif" font-size="28" letter-spacing="0.24em">LUMINARIA</text>
+    <text x="36" y="130" fill="#bae6fd" font-family="'Orbitron', sans-serif" font-size="20" letter-spacing="0.34em">CIRCUIT</text>
+    <text x="36" y="164" fill="#bae6fd" font-family="'Rajdhani', sans-serif" font-size="16" opacity="0.88">Sky-Lounges · Prism Tribünen · Voltaic Fountain</text>
+    <text x="36" y="190" fill="#7dd3fc" font-family="'Rajdhani', sans-serif" font-size="14" opacity="0.82">Crew Callouts: Halo Grandstand · Meridian Pit Spine · Aurora Carousel</text>
+  </g>
+
+  <g transform="translate(480 48)">
+    <rect width="360" height="304" rx="28" fill="url(#ionGradient)"/>
+    <rect width="360" height="304" rx="28" fill="url(#ionRim)" opacity="0.78"/>
+    <rect x="26" y="32" width="308" height="220" rx="18" fill="url(#ionGlow)"/>
+    <g fill="#c084fc" opacity="0.5">
+      <rect x="48" y="72" width="58" height="10" rx="5"/>
+      <rect x="116" y="58" width="70" height="14" rx="6"/>
+      <rect x="206" y="68" width="80" height="12" rx="6"/>
+    </g>
+    <g fill="none" stroke="#a855f7" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M64 256 C94 182 156 140 214 150 C268 160 312 212 302 270" opacity="0.92"/>
+      <path d="M86 244 C122 184 180 150 234 160 C272 168 294 198 288 234" stroke-dasharray="14 10" opacity="0.65"/>
+      <circle cx="214" cy="150" r="9" fill="#a855f7"/>
+      <circle cx="302" cy="270" r="9" fill="#a855f7"/>
+    </g>
+    <g fill="#d8b4fe" opacity="0.5">
+      <polygon points="64,208 108,208 96,232 52,232"/>
+      <polygon points="154,214 206,214 194,240 142,240"/>
+      <polygon points="232,224 288,224 276,246 220,246"/>
+    </g>
+    <text x="36" y="96" fill="#f5f3ff" font-family="'Orbitron', sans-serif" font-size="28" letter-spacing="0.28em">ION</text>
+    <text x="36" y="130" fill="#ede9fe" font-family="'Orbitron', sans-serif" font-size="20" letter-spacing="0.32em">VELODROME</text>
+    <text x="36" y="164" fill="#ede9fe" font-family="'Rajdhani', sans-serif" font-size="16" opacity="0.88">Flux-Tunnels · Cycler Loop · Arena-Foreshores</text>
+    <text x="36" y="190" fill="#d8b4fe" font-family="'Rajdhani', sans-serif" font-size="14" opacity="0.82">Crew Callouts: Dynamo Spire · Staccato Grandstand · Phase Gate</text>
+  </g>
+
+  <g transform="translate(920 48)">
+    <rect width="360" height="304" rx="28" fill="url(#forumGradient)"/>
+    <rect width="360" height="304" rx="28" fill="url(#forumRim)" opacity="0.82"/>
+    <rect x="26" y="32" width="308" height="220" rx="18" fill="url(#forumGlow)"/>
+    <g fill="#f97316" opacity="0.55">
+      <rect x="52" y="74" width="60" height="10" rx="5"/>
+      <rect x="124" y="60" width="78" height="12" rx="6"/>
+      <rect x="212" y="70" width="88" height="12" rx="6"/>
+    </g>
+    <g fill="none" stroke="#fb923c" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M62 252 C92 188 150 154 212 164 C268 174 312 214 308 266" opacity="0.9"/>
+      <path d="M86 238 C122 186 176 156 232 166 C272 174 294 202 294 238" stroke-dasharray="14 10" opacity="0.65"/>
+      <circle cx="212" cy="164" r="9" fill="#fb923c"/>
+      <circle cx="308" cy="266" r="9" fill="#fb923c"/>
+    </g>
+    <g fill="#fb923c" opacity="0.55">
+      <rect x="60" y="214" width="48" height="12" rx="6"/>
+      <rect x="132" y="226" width="58" height="12" rx="6"/>
+      <rect x="214" y="216" width="56" height="12" rx="6"/>
+      <rect x="264" y="232" width="44" height="12" rx="6"/>
+    </g>
+    <text x="36" y="96" fill="#ffedd5" font-family="'Orbitron', sans-serif" font-size="28" letter-spacing="0.26em">PARALLAX</text>
+    <text x="36" y="130" fill="#fed7aa" font-family="'Orbitron', sans-serif" font-size="20" letter-spacing="0.34em">FORUM</text>
+    <text x="36" y="164" fill="#fed7aa" font-family="'Rajdhani', sans-serif" font-size="16" opacity="0.88">Stadion-Terrassen · Chorus Stands · Solar Tapestries</text>
+    <text x="36" y="190" fill="#fdba74" font-family="'Rajdhani', sans-serif" font-size="14" opacity="0.82">Crew Callouts: Orbit Gallery · Horizon Podium · Ember Gallery</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- craft a second trio of track concept posters featuring Comet Trench, Quantum Bloom, and Umbra Expanse
- design a vanguard pixel art sheet for the Prism Rider, Eclipse Talon, and Grav Seraph gliders
- illustrate a widescreen key-art triptych capturing the new circuit atmospheres and document the assets in the README
- expand the asset library with a stadium-focused track concept triptych for Luminaria Circuit, Ion Velodrome, and Parallax Forum
- render a grandstand panorama plus a fresh Vanguard pixel set and crest collection to support spectator vibes and team branding
- add a DLC asset pack folder with Nova Rift posters, Helix Downforce blueprints, new glider pixel garage, broadcast overlays, and team crests

## Testing
- not run (art asset updates)

------
https://chatgpt.com/codex/tasks/task_e_68d0b1e321e48324b91c6638bfa24c42

## Summary by Sourcery

Add a comprehensive suite of new concept art and pixel art assets for Spacer-X circuits, teams, and DLC content

Enhancements:
- Add multiple track concept triptychs for new circuits including Comet Trench, Quantum Bloom, Umbra Expanse, Luminaria Circuit, Ion Velodrome, and Parallax Forum
- Add widescreen key-art triptych and grandstand panorama scenes capturing circuit atmospheres
- Add Vanguard pixel art sheets for Prism Rider, Eclipse Talon, Grav Seraph, Zenith Wyvern, Halo Riptide, and Comet Barricade gliders
- Add new team crest set for Aurora Wardens, Nova Paladins, Ember Vanguard, Tidal Oracle, Prism Lilith, Greenline Rally, and DLC teams
- Add DLC asset pack containing track posters, blueprints, environment backdrops, glider concepts, broadcast overlay kit, and team logos

Documentation:
- Update README to document all newly added art assets