### PR TITLE
Add automated smoke test and cleanup script initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Futuristisches Top‑Down‑Racing mit TV‑UI, 18 Strecken (u. a. Atlas Skywa
 2. `index.html` im Browser öffnen (oder optional: `python3 -m http.server`)
 3. **Einstellungen**: Strecke & Runden wählen → **Schnelles Rennen** oder **Grand Prix** starten
 
+## Automatischer Smoke-Test
+- **Voraussetzungen:** Node.js ≥ 18, npm und Netzwerkausgang (Puppeteer lädt beim ersten Durchlauf eine Headless-Chromium-Binary).
+- **Installation:** `npm install`
+- **Ausführung:** `npm run smoke`
+
+Das Skript `tests/full_smoke.mjs` startet Spacer‑X in einem lokalen Headless-Chromium, setzt die Broadcast-Intros aus, fährt ein Schnellrennen bis ins Ziel, beendet den ersten Grand-Prix-Lauf und simuliert eine Manager-Woche. Währenddessen werden die relevanten UI-Schaltflächen über `window.spacerxDiagnostics.getControlState()` geprüft, damit Fehler in der Race-Control- und Manager-Progression früh auffallen.
+
 ## Ordner & Dateien
 - `index.html` – UI & Screens (Main Menu, Race, Teams, Settings)
 - `styles.css` – Dark/Neo‑Noir Theme, Banner, Ticker, Mini‑Map

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1289 @@
+{
+  "name": "spacer-x",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "spacer-x",
+      "version": "1.0.0",
+      "devDependencies": {
+        "puppeteer": "^22.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
+      "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.4.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.1.tgz",
+      "integrity": "sha512-ZovbrBV0g6JxK5cGUF1Suby1vLfKjv4RWi8IxoaO/Mon8BDD9I21RxjHFtgQ+kskJqLAVyQZly3uMBui+vhc8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.7.0.tgz",
+      "integrity": "sha512-b3N5eTW1g7vXkw+0CXh/HazGTcO5KYuu/RCNaJbDMPI6LHDi+7qe8EmxKUVe1sUbY2KZOVZFyj62x0OEz9qyAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.4.4.tgz",
+      "integrity": "sha512-Q8yxM1eLhJfuM7KXVP3zjhBvtMJCYRByoTT+wHXjpdMELv0xICFJX+1w4c7csa+WZEOsq4ItJ4RGwvzid6m/dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.2.2.tgz",
+      "integrity": "sha512-g+ueNGKkrjMazDG3elZO1pNs3HY5+mMmOet1jtKyhOaCnkLzitxf26z7hoAEkDNgdNmnc1KIlt/dw6Po6xZMpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
+      "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1312386",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "22.15.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.15.0.tgz",
+      "integrity": "sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==",
+      "deprecated": "< 24.10.2 is no longer supported",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.3.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1312386",
+        "puppeteer-core": "22.15.0"
+      },
+      "bin": {
+        "puppeteer": "lib/esm/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "22.15.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
+      "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.3.0",
+        "chromium-bidi": "0.6.3",
+        "debug": "^4.3.6",
+        "devtools-protocol": "0.0.1312386",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "spacer-x",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "smoke": "node tests/full_smoke.mjs"
+  },
+  "devDependencies": {
+    "puppeteer": "^22.6.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -262,6 +262,7 @@
       const clone = { ...variant };
       clone.summary = describeVariantProfile(clone);
       return clone;
+    }
     const traits = [];
     if (variant.engine > 1.05 || variant.boost > 1.05) traits.push('Top-End Boost');
     if (variant.aero > 1.05 || variant.handling > 1.05) traits.push('Kurvengriff');
@@ -598,10 +599,6 @@
       console.warn('manager state save failed', err);
     }
   }
-  if (toggleFocusPanel) {
-    toggleFocusPanel.checked = uiSettings.showFocusPanel;
-  }
-  applyUiSettings();
 
   function ensureFreeAgentPool() {
     if (!managerState || !managerState.teams) return;
@@ -773,7 +770,14 @@
     const base = defaultChassisSpec.geometry;
     if (!geometry || typeof geometry !== 'object') {
       return { ...base };
-  const gpTrackRotation = ['oval', 'atlas', 'solstice', 'mirage', 'lumen'];
+    }
+    return {
+      length: clamp(Number.isFinite(geometry.length) ? geometry.length : base.length, 20, 40),
+      width: clamp(Number.isFinite(geometry.width) ? geometry.width : base.width, 12, 24),
+      nose: clamp(Number.isFinite(geometry.nose) ? geometry.nose : base.nose, 3, 10),
+      canopy: clamp(Number.isFinite(geometry.canopy) ? geometry.canopy : base.canopy, 8, 18)
+    };
+  }
 
   const mainMenu = document.getElementById('mainMenu');
   const raceScreen = document.getElementById('raceScreen');
@@ -812,18 +816,34 @@
   const raceTimeLabel = document.getElementById('raceTimeLabel');
   const resultsLabel = document.getElementById('resultsLabel');
   const teamsList = document.getElementById('teamsList');
+  const contentRoadmapPanel = document.getElementById('contentRoadmap');
+  const integrationRoadmapPanel = document.getElementById('integrationRoadmap');
   const top3Banner = document.getElementById('top3Banner');
+  const restartHoldBanner = document.getElementById('restartHoldBanner');
+  const broadcastIntro = document.getElementById('broadcastIntro');
+  const broadcastIntroHeadline = document.getElementById('broadcastIntroHeadline');
+  const broadcastIntroSummary = document.getElementById('broadcastIntroSummary');
+  const broadcastIntroLeaders = document.getElementById('broadcastIntroLeaders');
+  const broadcastIntroSkip = document.getElementById('broadcastIntroSkip');
   const raceFlag = document.getElementById('raceFlag');
   const highlightTicker = document.getElementById('highlightTicker');
   const leaderboardHud = document.getElementById('leaderboardHud');
   const leaderboardList = leaderboardHud?.querySelector('ol');
+  const liveTickerPanel = document.querySelector('.liveTickerPanel');
   const liveTickerList = document.getElementById('liveTickerList');
   const sessionInfo = document.getElementById('sessionInfo');
   const leaderGapHud = document.getElementById('leaderGapHud');
   const leaderGapLabel = leaderGapHud?.querySelector('.label');
   const leaderGapDelta = leaderGapHud?.querySelector('.delta');
   const leaderGapFill = leaderGapHud?.querySelector('.gapBar .fill');
+  const startLights = document.getElementById('startLights');
+  const startLightBulbs = startLights ? Array.from(startLights.querySelectorAll('.light')) : [];
+  const marshalOverlay = document.getElementById('marshalOverlay');
+  const marshalMessage = document.getElementById('marshalMessage');
   const cameraHud = document.getElementById('cameraHud');
+  const eventBanner = document.getElementById('eventBanner');
+  const eventBannerPrimary = eventBanner?.querySelector('.primary') || null;
+  const eventBannerSecondary = eventBanner?.querySelector('.secondary') || null;
   const sectorWidget = document.getElementById('sectorWidget');
   const fastestLapLabel = document.getElementById('fastestLapLabel');
   const focusDriverPanel = document.getElementById('focusDriverPanel');
@@ -831,6 +851,7 @@
   const focusDriverMeta = document.getElementById('focusDriverMeta');
   const focusDriverStats = document.getElementById('focusDriverStats');
   const focusDriverTrend = document.getElementById('focusDriverTrend');
+  const toggleFocusPanel = document.getElementById('toggleFocusPanel');
   const raceControlPanel = document.getElementById('raceControlPanel');
   const raceControlLog = document.getElementById('raceControlLog');
   const gridIntroOverlay = document.getElementById('gridIntro');
@@ -838,6 +859,7 @@
   const gridIntroMeta = document.getElementById('gridIntroMeta');
   const gridIntroDismiss = document.getElementById('gridIntroDismiss');
   const gridIntroTimer = document.getElementById('gridIntroTimer');
+  const gpStatusCard = document.getElementById('gpStatusCard');
   const replayControls = document.getElementById('replayControls');
   const replayPlayPauseBtn = document.getElementById('replayPlayPause');
   const replayScrubber = document.getElementById('replayScrubber');
@@ -850,6 +872,10 @@
   function setStartButtonState(enabled, label = 'Rennen starten') {
     if (!startRaceBtn) return;
     startRaceBtn.disabled = !enabled;
+    if (typeof startRaceBtn.toggleAttribute === 'function') {
+      startRaceBtn.toggleAttribute('disabled', !enabled);
+    }
+    startRaceBtn.setAttribute('aria-disabled', String(!enabled));
     if (label) {
       startRaceBtn.textContent = label;
     }
@@ -858,15 +884,13 @@
   function setPauseButtonState(enabled, label = 'Pause') {
     if (!pauseRaceBtn) return;
     pauseRaceBtn.disabled = !enabled;
+    if (typeof pauseRaceBtn.toggleAttribute === 'function') {
+      pauseRaceBtn.toggleAttribute('disabled', !enabled);
+    }
+    pauseRaceBtn.setAttribute('aria-disabled', String(!enabled));
     if (label) {
       pauseRaceBtn.textContent = label;
     }
-    return {
-      length: clamp(Number.isFinite(geometry.length) ? geometry.length : base.length, 20, 40),
-      width: clamp(Number.isFinite(geometry.width) ? geometry.width : base.width, 12, 24),
-      nose: clamp(Number.isFinite(geometry.nose) ? geometry.nose : base.nose, 3, 10),
-      canopy: clamp(Number.isFinite(geometry.canopy) ? geometry.canopy : base.canopy, 8, 18)
-    };
   }
 
   function sanitizeGarageSnapshot(data) {
@@ -1045,143 +1069,8 @@
     const gpSnapshot = sanitizeGpSnapshot(snapshot.gp);
     gpTable.clear();
     gpSnapshot.table.forEach(entry => {
+      if (!entry || typeof entry !== 'object' || typeof entry.driver !== 'string') return;
       gpTable.set(entry.driver, entry);
-  function resetRaceControls() {
-    setPauseButtonState(false, 'Pause');
-    setStartButtonState(true, 'Rennen starten');
-    if (replayRaceBtn) {
-      replayRaceBtn.style.display = 'none';
-      replayRaceBtn.textContent = 'Replay';
-    }
-    if (replayControls) {
-      replayControls.classList.add('hidden');
-      replayControls.setAttribute('aria-hidden', 'true');
-    }
-  }
-
-  function hidePodiumOverlay(clear = false) {
-    if (podiumOverlay) {
-      podiumOverlay.classList.add('hidden');
-      podiumOverlay.setAttribute('aria-hidden', 'true');
-    }
-    if (podiumTimer) {
-      clearTimeout(podiumTimer);
-      podiumTimer = null;
-    }
-    if (clear && podiumList) {
-      podiumList.innerHTML = '';
-    }
-  }
-
-  function showPodium(order) {
-    if (!podiumOverlay || !podiumList) return;
-    podiumList.innerHTML = '';
-    if (!Array.isArray(order) || order.length === 0) {
-      hidePodiumOverlay(true);
-      return;
-    }
-    const leader = order[0];
-    const medals = ['gold', 'silver', 'bronze'];
-    const frag = document.createDocumentFragment();
-    order.slice(0, 3).forEach((car, idx) => {
-      if (!car) return;
-      const li = document.createElement('li');
-      if (medals[idx]) li.classList.add(medals[idx]);
-      const pos = document.createElement('span');
-      pos.className = 'pos';
-      pos.textContent = `${idx + 1}.`;
-      const meta = document.createElement('div');
-      meta.className = 'meta';
-      const name = document.createElement('strong');
-      name.textContent = `#${car.racingNumber} ${car.driver}`;
-      name.style.color = car.color;
-      const team = document.createElement('span');
-      team.textContent = car.team;
-      const detail = document.createElement('span');
-      if (idx === 0) {
-        detail.textContent = car.finishTime != null ? `Gesamt: ${formatTime(car.finishTime)}` : 'Gesamt: --';
-      } else if (leader && leader.finishTime != null && car.finishTime != null) {
-        const gap = Math.max(0, car.finishTime - leader.finishTime);
-        detail.textContent = `Gap: +${formatGap(gap)}s`;
-      } else {
-        detail.textContent = 'Gap: --';
-      }
-      meta.appendChild(name);
-      meta.appendChild(team);
-      meta.appendChild(detail);
-      li.appendChild(pos);
-      li.appendChild(meta);
-      frag.appendChild(li);
-    });
-    podiumList.appendChild(frag);
-    podiumOverlay.classList.remove('hidden');
-    podiumOverlay.setAttribute('aria-hidden', 'false');
-    if (podiumTimer) clearTimeout(podiumTimer);
-    podiumTimer = setTimeout(() => hidePodiumOverlay(false), 8000);
-  }
-
-  function stopReplay(resetView = true) {
-    if (replayRafId) {
-      cancelAnimationFrame(replayRafId);
-      replayRafId = 0;
-    }
-    replayActive = false;
-    replayPlaying = false;
-    replayAccumulator = 0;
-    replayLastTimestamp = 0;
-    if (replayControls) {
-      replayControls.classList.add('hidden');
-      replayControls.setAttribute('aria-hidden', 'true');
-    }
-    if (replayPlayPauseBtn) {
-      replayPlayPauseBtn.textContent = '▶︎';
-      replayPlayPauseBtn.setAttribute('aria-label', 'Replay abspielen');
-    }
-    if (replayRaceBtn) {
-      replayRaceBtn.textContent = 'Replay ansehen';
-    }
-    if (sessionInfo && replaySessionInfoCache) {
-      sessionInfo.textContent = replaySessionInfoCache.text || '';
-      sessionInfo.classList.toggle('hidden', replaySessionInfoCache.hidden);
-      replaySessionInfoCache = null;
-    }
-    if (resetView) {
-      drawScene();
-      updateSessionInfo();
-    }
-  }
-
-  function clearReplayData() {
-    stopReplay(false);
-    replayBuffer.length = 0;
-    replayMeta = new Map();
-    replayCarState = new Map();
-    replayCursor = 0;
-    replayAccumulator = 0;
-    replayAppliedIndex = -1;
-    replayTotalDuration = 0;
-    if (replayScrubber) {
-      replayScrubber.value = '0';
-      replayScrubber.max = '1';
-    }
-    if (replayTimeLabel) {
-      replayTimeLabel.textContent = '0,0s / 0,0s';
-    }
-  }
-
-  function prepareReplayMeta() {
-    replayMeta = new Map();
-    cars.forEach(car => {
-      replayMeta.set(car.id, {
-        id: car.id,
-        driver: car.driver,
-        team: car.team,
-        racingNumber: car.racingNumber,
-        color: car.color,
-        baseSpeed: car.baseSpeed,
-        profile: car.profile,
-        bodyGeometry: car.bodyGeometry || defaultChassisSpec.geometry
-      });
     });
     gpRaceIndex = gpSnapshot.raceIndex;
     gpActive = gpSnapshot.active;
@@ -1253,129 +1142,12 @@
     renderTeams();
   }
 
-  const mainMenu = document.getElementById('mainMenu');
-  const raceScreen = document.getElementById('raceScreen');
-  const teamsScreen = document.getElementById('teamsScreen');
-  const managerScreen = document.getElementById('managerScreen');
-  const bettingScreen = document.getElementById('bettingScreen');
-  const codexScreen = document.getElementById('codexScreen');
-  const settingsScreen = document.getElementById('settingsScreen');
-
-  const newRaceBtn = document.getElementById('newRaceBtn');
-  const grandPrixBtn = document.getElementById('grandPrixBtn');
-  const resumeGrandPrixBtn = document.getElementById('resumeGrandPrixBtn');
-  const gpStatusCard = document.getElementById('grandPrixStatusCard');
-  const gpStatusMeta = document.getElementById('gpStatusMeta');
-  const gpStatusTrack = document.getElementById('gpStatusTrack');
-  const gpStatusWeather = document.getElementById('gpStatusWeather');
-  const gpStatusStandings = document.getElementById('gpStatusStandings');
-  const gpStatusEmpty = document.getElementById('gpStatusEmpty');
-  const managerBtn = document.getElementById('managerBtn');
-  const bettingBtn = document.getElementById('bettingBtn');
-  const teamsBtn = document.getElementById('teamsBtn');
-  const codexBtn = document.getElementById('codexBtn');
-  const settingsBtn = document.getElementById('settingsBtn');
-
-  const backToMenuFromRace = document.getElementById('backToMenuFromRace');
-  const backToMenuFromTeams = document.getElementById('backToMenuFromTeams');
-  const backToMenuFromManager = document.getElementById('backToMenuFromManager');
-  const backToMenuFromBetting = document.getElementById('backToMenuFromBetting');
-  const backToMenuFromCodex = document.getElementById('backToMenuFromCodex');
-  const backToMenuFromSettings = document.getElementById('backToMenuFromSettings');
-
-  const canvas = document.getElementById('raceCanvas');
-  const ctx = canvas.getContext('2d');
-  const miniMap = document.getElementById('miniMapCanvas');
-  const mm = miniMap.getContext('2d');
-  const canvasWrap = document.querySelector('.canvasWrap');
-  const startRaceBtn = document.getElementById('startRaceBtn');
-  const pauseRaceBtn = document.getElementById('pauseRaceBtn');
-  const replayRaceBtn = document.getElementById('replayRaceBtn');
-  const nextRaceBtn = document.getElementById('nextRaceBtn');
-  const telemetryList = document.getElementById('telemetryList');
-  const lapInfoLabel = document.getElementById('lapInfoLabel');
-  const raceTimeLabel = document.getElementById('raceTimeLabel');
-  const resultsLabel = document.getElementById('resultsLabel');
-  const teamsList = document.getElementById('teamsList');
-  const contentRoadmapPanel = document.getElementById('contentRoadmap');
-  const integrationRoadmapPanel = document.getElementById('integrationRoadmap');
-  const top3Banner = document.getElementById('top3Banner');
-  const restartHoldBanner = document.getElementById('restartHoldBanner');
-  const broadcastIntro = document.getElementById('broadcastIntro');
-  const broadcastIntroHeadline = document.getElementById('broadcastIntroHeadline');
-  const broadcastIntroSummary = document.getElementById('broadcastIntroSummary');
-  const broadcastIntroLeaders = document.getElementById('broadcastIntroLeaders');
-  const broadcastIntroSkip = document.getElementById('broadcastIntroSkip');
-  const raceFlag = document.getElementById('raceFlag');
-  const highlightTicker = document.getElementById('highlightTicker');
-  const leaderboardHud = document.getElementById('leaderboardHud');
-  const leaderboardList = leaderboardHud?.querySelector('ol');
-  const liveTickerList = document.getElementById('liveTickerList');
-  const liveTickerPanel = document.querySelector('.liveTickerPanel');
-  const sessionInfo = document.getElementById('sessionInfo');
-  const leaderGapHud = document.getElementById('leaderGapHud');
-  const leaderGapLabel = leaderGapHud?.querySelector('.label');
-  const leaderGapDelta = leaderGapHud?.querySelector('.delta');
-  const leaderGapFill = leaderGapHud?.querySelector('.gapBar .fill');
-  const startLights = document.getElementById('startLights');
-  const startLightBulbs = startLights ? Array.from(startLights.querySelectorAll('.light')) : [];
-  const marshalOverlay = document.getElementById('marshalOverlay');
-  const marshalMessage = document.getElementById('marshalMessage');
-  const cameraHud = document.getElementById('cameraHud');
-  const eventBanner = document.getElementById('eventBanner');
-  const eventBannerPrimary = eventBanner?.querySelector('.primary') || null;
-  const eventBannerSecondary = eventBanner?.querySelector('.secondary') || null;
-  const sectorWidget = document.getElementById('sectorWidget');
-  const fastestLapLabel = document.getElementById('fastestLapLabel');
-  const focusDriverPanel = document.getElementById('focusDriverPanel');
-  const focusDriverName = document.getElementById('focusDriverName');
-  const focusDriverMeta = document.getElementById('focusDriverMeta');
-  const focusDriverStats = document.getElementById('focusDriverStats');
-  const focusDriverTrend = document.getElementById('focusDriverTrend');
-  const raceControlPanel = document.getElementById('raceControlPanel');
-  const raceControlLog = document.getElementById('raceControlLog');
-  const gridIntroOverlay = document.getElementById('gridIntro');
-  const gridIntroList = document.getElementById('gridIntroList');
-  const gridIntroMeta = document.getElementById('gridIntroMeta');
-  const gridIntroDismiss = document.getElementById('gridIntroDismiss');
-  const gridIntroTimer = document.getElementById('gridIntroTimer');
-  const replayControls = document.getElementById('replayControls');
-  const replayPlayPauseBtn = document.getElementById('replayPlayPause');
-  const replayScrubber = document.getElementById('replayScrubber');
-  const replayTimeLabel = document.getElementById('replayTimeLabel');
-  const replaySpeedSelect = document.getElementById('replaySpeed');
-  const podiumOverlay = document.getElementById('podiumOverlay');
-  const podiumList = document.getElementById('podiumList');
-  const podiumCloseBtn = document.getElementById('podiumCloseBtn');
   let marshalHideTimer = null;
+  let startLightClearTimer = null;
   let titleThemeStarted = false;
   let titleThemeArmed = false;
   let titleThemeGain = null;
   let titleThemeSources = [];
-
-  function setStartButtonState(enabled, label = 'Rennen starten') {
-    if (!startRaceBtn) return;
-    startRaceBtn.disabled = !enabled;
-    if (typeof startRaceBtn.toggleAttribute === 'function') {
-      startRaceBtn.toggleAttribute('disabled', !enabled);
-    }
-    startRaceBtn.setAttribute('aria-disabled', String(!enabled));
-    if (label) {
-      startRaceBtn.textContent = label;
-    }
-  }
-
-  function setPauseButtonState(enabled, label = 'Pause') {
-    if (!pauseRaceBtn) return;
-    pauseRaceBtn.disabled = !enabled;
-    if (typeof pauseRaceBtn.toggleAttribute === 'function') {
-      pauseRaceBtn.toggleAttribute('disabled', !enabled);
-    }
-    pauseRaceBtn.setAttribute('aria-disabled', String(!enabled));
-    if (label) {
-      pauseRaceBtn.textContent = label;
-    }
-  }
 
   function clearHighlightTickerClasses() {
     if (!highlightTicker) return;
@@ -2183,7 +1955,6 @@
   const startProc = document.getElementById('startProc');
   const weatherSetting = document.getElementById('weatherSetting');
   const toggleRaceControl = document.getElementById('toggleRaceControl');
-  const toggleFocusPanel = document.getElementById('toggleFocusPanel');
   const toggleMiniMap = document.getElementById('toggleMiniMap');
   const toggleBroadcastIntro = document.getElementById('toggleBroadcastIntro');
   const toggleTicker = document.getElementById('toggleTicker');
@@ -2234,21 +2005,14 @@
   const wipeProfileBtn = document.getElementById('wipeProfileBtn');
   const settingsNotice = document.getElementById('settingsNotice');
 
-  const uiSettings = loadUiSettings();
-  syncUiSettingControls();
-  applyUiSettings();
-  armTitleThemeTrigger();
-  resetLiveTicker();
-  updateLeaderboardHud([]);
-  resetRaceControls();
-
-  let raceSettings = loadRaceSettings();
-  let currentTrackType = raceSettings.track || 'oval';
-  let totalLaps = Number.isFinite(raceSettings.laps) ? raceSettings.laps : 15;
-  let aiLevel = raceSettings.ai || 'normal';
-  let currentWeather = raceSettings.weather || 'clear';
-  let startProcedureMode = raceSettings.startProc || 'standing';
-  let activeTrackTraits = getTrackTraits(currentTrackType);
+  let uiSettings;
+  let raceSettings;
+  let currentTrackType = 'oval';
+  let totalLaps = 15;
+  let aiLevel = 'normal';
+  let currentWeather = 'clear';
+  let startProcedureMode = 'standing';
+  let activeTrackTraits = null;
   let currentVisualTheme = null;
   let lastTelemetryOrder = [];
   const raceControlEvents = [];
@@ -2264,8 +2028,6 @@
   const flowAudit = [];
   const leaderboardGapHistory = new Map();
   let settingsNoticeTimer = null;
-
-  syncRaceSettingControls();
 
   trackTypeSelect?.addEventListener('change', () => {
     currentTrackType = trackTypeSelect.value;
@@ -2516,7 +2278,6 @@
   const jumpStartWarnings = new Set();
   let jumpStartArmed = false;
   let startLightsActiveTotal = 5;
-  let startLightClearTimer = null;
   let audioCtx = null;
 
   function getRacePaceMultiplier() {
@@ -7149,6 +6910,57 @@
     startRace();
   });
 
+  function isElementVisible(element) {
+    if (!element) return false;
+    if (element.hidden) return false;
+    const style = window.getComputedStyle(element);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+    if (parseFloat(style.opacity || '1') === 0) return false;
+    if (element.closest('[aria-hidden="true"]')) return false;
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
+  function getButtonDiagnostics(element) {
+    if (!element) return null;
+    const text = (element.textContent || '').replace(/\s+/g, ' ').trim();
+    const disabled = !!element.disabled;
+    return {
+      text,
+      disabled,
+      enabled: !disabled,
+      visible: isElementVisible(element)
+    };
+  }
+
+  function initializeAppState() {
+    uiSettings = loadUiSettings();
+    syncUiSettingControls();
+    applyUiSettings();
+    armTitleThemeTrigger();
+    resetLiveTicker();
+
+    raceSettings = loadRaceSettings();
+    currentTrackType = raceSettings.track || 'oval';
+    totalLaps = Number.isFinite(raceSettings.laps) ? raceSettings.laps : 15;
+    aiLevel = raceSettings.ai || 'normal';
+    currentWeather = raceSettings.weather || 'clear';
+    startProcedureMode = raceSettings.startProc || 'standing';
+    activeTrackTraits = getTrackTraits(currentTrackType);
+    currentVisualTheme = null;
+    lastTelemetryOrder = [];
+
+    updateEventBriefing();
+    updateActiveTrackTraits();
+    rebuildMini();
+    refreshOddsTable();
+    updateLeaderboardHud([]);
+    syncRaceSettingControls();
+    resetRaceControls();
+  }
+
+  initializeAppState();
+
   if (typeof window !== 'undefined') {
     window.spacerxDiagnostics = {
       getPhaseTimeline: () => phaseTimeline.map(entry => {
@@ -7173,6 +6985,54 @@
       reset: () => {
         phaseTimeline.length = 0;
         flowAudit.length = 0;
+      },
+      getControlState: () => {
+        const activeScreen = document.querySelector('.screen.active');
+        const managerSnapshot = managerState || {};
+        return {
+          screen: activeScreen?.id || null,
+          mode: currentMode || null,
+          race: {
+            phase: racePhase,
+            active: !!raceActive,
+            countdown: !!countdownRunning,
+            finished: racePhase === 'FINISHED' && !raceActive,
+            totalLaps,
+            lapLabel: lapInfoLabel?.textContent || null,
+            sessionBanner: sessionInfo?.classList.contains('hidden') ? null : (sessionInfo?.textContent || null),
+            timelineEntries: phaseTimeline.length
+          },
+          gp: {
+            active: !!gpActive,
+            raceIndex: gpRaceIndex,
+            totalRaces: GP_RACES,
+            nextRaceReady: !!(getButtonDiagnostics(nextRaceBtn)?.visible),
+            hasProgress: hasGrandPrixProgress()
+          },
+          manager: {
+            seasonYear: managerSnapshot.seasonYear ?? null,
+            week: managerSnapshot.week ?? null,
+            selectedTeam: managerSnapshot.selectedTeam ?? null
+          },
+          buttons: {
+            newRace: getButtonDiagnostics(newRaceBtn),
+            grandPrix: getButtonDiagnostics(grandPrixBtn),
+            resumeGrandPrix: getButtonDiagnostics(resumeGrandPrixBtn),
+            startRace: getButtonDiagnostics(startRaceBtn),
+            pauseRace: getButtonDiagnostics(pauseRaceBtn),
+            replayRace: getButtonDiagnostics(replayRaceBtn),
+            nextRace: getButtonDiagnostics(nextRaceBtn),
+            managerWeek: getButtonDiagnostics(advanceManagerWeekBtn),
+            managerStart: getButtonDiagnostics(managerStartRaceBtn),
+            backToMenuFromRace: getButtonDiagnostics(backToMenuFromRace),
+            backToMenuFromManager: getButtonDiagnostics(backToMenuFromManager)
+          },
+          overlays: {
+            broadcastIntro: isElementVisible(broadcastIntro),
+            gridIntro: isElementVisible(gridIntroOverlay),
+            podium: isElementVisible(podiumOverlay)
+          }
+        };
       }
     };
   }

--- a/tests/MANUAL_CHECKLIST.md
+++ b/tests/MANUAL_CHECKLIST.md
@@ -6,3 +6,11 @@
 - [ ] TV: Top‑3 Banner sichtbar, Ticker bei Events
 - [ ] Mini‑Map zeigt Cars korrekt
 - [ ] Settings: Runden & Strecke greifen
+
+## Automatisierte Abdeckung
+- `npm run smoke` (Headless Chromium) fährt ein Schnellrennen zu Ende, beendet Lauf 1 des Grand Prix und simuliert eine Manager-Woche. Dabei werden die Button-Zustände über `window.spacerxDiagnostics.getControlState()` geprüft.
+
+## Manueller Fallback bei fehlgeschlagenem Smoke-Test
+- [ ] Schnellrennen manuell durchspielen und sicherstellen, dass Start-/Pause-Buttons wie im automatischen Lauf reagieren.
+- [ ] Nach Rennen 1 im Grand Prix prüfen, ob „Nächstes Rennen“ sichtbar ist und der Start-Button „Rennen 2 starten“ anzeigt (entspricht den Smoke-Test-Assertions).
+- [ ] Im Manager-Screen „Nächste Woche simulieren“ klicken und bestätigen, dass der Wochenzähler um +1 steigt – wie im automatisierten Lauf erwartet.

--- a/tests/full_smoke.mjs
+++ b/tests/full_smoke.mjs
@@ -1,0 +1,303 @@
+import { createServer } from 'http';
+import { readFile, stat } from 'fs/promises';
+import { extname, join, resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import puppeteer from 'puppeteer';
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=UTF-8',
+  '.js': 'application/javascript; charset=UTF-8',
+  '.mjs': 'application/javascript; charset=UTF-8',
+  '.css': 'text/css; charset=UTF-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.json': 'application/json; charset=UTF-8',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav'
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT_DIR = resolve(__dirname, '..');
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function createStaticServer(rootDir) {
+  const server = createServer(async (req, res) => {
+    try {
+      const requestUrl = new URL(req.url || '/', 'http://localhost');
+      let pathname = decodeURIComponent(requestUrl.pathname);
+      if (!pathname || pathname === '/') {
+        pathname = '/index.html';
+      }
+      const safePath = pathname.replace(/^\/+/, '');
+      let filePath = resolve(rootDir, safePath);
+      if (!filePath.startsWith(rootDir)) {
+        res.writeHead(403).end('Forbidden');
+        return;
+      }
+      let fileStat;
+      try {
+        fileStat = await stat(filePath);
+      } catch (error) {
+        if (error.code === 'ENOENT') {
+          console.warn(`Static 404: ${pathname}`);
+          res.writeHead(404).end('Not found');
+          return;
+        }
+        throw error;
+      }
+      if (fileStat.isDirectory()) {
+        filePath = join(filePath, 'index.html');
+      }
+      const data = await readFile(filePath);
+      const contentType = MIME_TYPES[extname(filePath).toLowerCase()] || 'application/octet-stream';
+      res.writeHead(200, {
+        'Content-Type': contentType,
+        'Cache-Control': 'no-cache'
+      });
+      res.end(data);
+    } catch (error) {
+      console.error('Static server error:', error);
+      res.writeHead(500).end('Internal Server Error');
+    }
+  });
+
+  await new Promise((resolvePromise, rejectPromise) => {
+    server.once('error', rejectPromise);
+    server.listen(0, '127.0.0.1', () => resolvePromise());
+  });
+  const address = server.address();
+  if (!address || typeof address.port !== 'number') {
+    throw new Error('Failed to start static server');
+  }
+  return { server, port: address.port };
+}
+
+async function closeServer(server) {
+  await new Promise(resolvePromise => server.close(resolvePromise));
+}
+
+async function waitForControlState(page, description, predicate, timeout = 20000, ...args) {
+  try {
+    await page.waitForFunction(predicate, { timeout }, ...args);
+  } catch (error) {
+    const lastState = await page.evaluate(() => window.spacerxDiagnostics?.getControlState?.());
+    throw new Error(
+      `Timeout while waiting for ${description}. Last control state: ${JSON.stringify(lastState, null, 2)}\n${error.message}`
+    );
+  }
+}
+
+async function getControlState(page) {
+  const state = await page.evaluate(() => window.spacerxDiagnostics?.getControlState?.());
+  if (!state) {
+    throw new Error('spacerxDiagnostics.getControlState() is unavailable');
+  }
+  return state;
+}
+
+async function dismissPodiumIfVisible(page) {
+  const podiumVisible = await page.evaluate(() => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.overlays?.podium === true;
+  });
+  if (podiumVisible) {
+    const button = await page.$('#podiumCloseBtn');
+    if (button) {
+      await button.click();
+      await page.waitForTimeout(200);
+    }
+  }
+}
+
+async function runQuickRace(page) {
+  console.log('▶ Running quick race…');
+  await waitForControlState(page, 'main menu', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.screen === 'mainMenu';
+  });
+
+  const initialState = await getControlState(page);
+  assert(initialState.buttons?.newRace?.enabled, 'Expected "Schnelles Rennen" to be enabled on load');
+
+  await page.click('#newRaceBtn');
+  await waitForControlState(page, 'race screen', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.screen === 'raceScreen';
+  });
+
+  const raceScreenState = await getControlState(page);
+  assert(raceScreenState.buttons?.startRace?.enabled, 'Start button should be active after entering race screen');
+
+  await page.click('#startRaceBtn');
+
+  await waitForControlState(page, 'race to arm', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.race?.countdown === true || diagnostics?.race?.active === true;
+  }, 10000);
+
+  await waitForControlState(page, 'green flag', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.race?.active === true && diagnostics?.race?.phase !== 'COUNTDOWN';
+  }, 20000);
+
+  await waitForControlState(page, 'race finish', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.race?.finished === true;
+  }, 120000);
+
+  await dismissPodiumIfVisible(page);
+
+  const finalState = await getControlState(page);
+  assert(finalState.buttons?.startRace?.enabled, 'Start button should re-enable after race completion');
+  console.log('✔ Quick race completed');
+}
+
+async function runGrandPrixRound(page) {
+  console.log('▶ Running first GP round…');
+  await page.click('#backToMenuFromRace');
+  await waitForControlState(page, 'return to main menu', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.screen === 'mainMenu';
+  });
+
+  await page.click('#grandPrixBtn');
+  await waitForControlState(page, 'GP race screen', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.screen === 'raceScreen';
+  });
+
+  await page.click('#startRaceBtn');
+
+  await waitForControlState(page, 'GP race active', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.race?.active === true;
+  }, 20000);
+
+  await waitForControlState(page, 'GP race finish', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.race?.finished === true;
+  }, 130000);
+
+  await dismissPodiumIfVisible(page);
+
+  const gpState = await getControlState(page);
+  assert(gpState.gp?.raceIndex === 1, 'Grand Prix should advance to race index 1 after first event');
+  assert(gpState.buttons?.nextRace?.visible, 'Next race button should be visible after finishing first GP event');
+  assert(/Rennen\s*2/.test(gpState.buttons?.startRace?.text || ''), 'Start button should show "Rennen 2 starten"');
+  console.log('✔ GP round advanced');
+}
+
+async function runManagerWeek(page) {
+  console.log('▶ Simulating manager week…');
+  await page.click('#backToMenuFromRace');
+  await waitForControlState(page, 'return to main menu from GP', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.screen === 'mainMenu';
+  });
+
+  const menuState = await getControlState(page);
+  assert(menuState.buttons?.resumeGrandPrix?.enabled, 'Resume GP button should be enabled after completing first race');
+
+  await page.click('#managerBtn');
+  await waitForControlState(page, 'manager screen', () => {
+    const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+    return diagnostics?.screen === 'managerScreen';
+  });
+
+  const managerState = await getControlState(page);
+  const currentWeek = managerState.manager?.week;
+  assert(Number.isInteger(currentWeek), 'Manager week should be an integer value');
+
+  await page.click('#advanceManagerWeekBtn');
+  await waitForControlState(
+    page,
+    'manager week increment',
+    expectedWeek => {
+      const diagnostics = window.spacerxDiagnostics?.getControlState?.();
+      return diagnostics?.manager?.week === expectedWeek;
+    },
+    20000,
+    currentWeek + 1
+  );
+
+  const updatedManagerState = await getControlState(page);
+  assert(
+    updatedManagerState.manager?.week === currentWeek + 1,
+    'Manager week counter should increment after simulating a week'
+  );
+  console.log('✔ Manager week simulated');
+}
+
+async function main() {
+  const { server, port } = await createStaticServer(ROOT_DIR);
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
+  const page = await browser.newPage();
+  page.setDefaultTimeout(45000);
+  page.setDefaultNavigationTimeout(45000);
+  page.on('console', message => {
+    console.log(`[browser:${message.type()}] ${message.text()}`);
+  });
+  page.on('pageerror', error => {
+    console.error('Browser error:', error && error.stack ? error.stack : error);
+  });
+  page.on('dialog', dialog => dialog.accept());
+
+  try {
+    const targetUrl = `http://127.0.0.1:${port}/index.html`;
+    await page.goto(targetUrl, { waitUntil: 'networkidle0' });
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+    await page.reload({ waitUntil: 'networkidle0' });
+
+    const scriptProbe = await page.evaluate(async () => {
+      const response = await fetch('script.js');
+      const body = await response.text();
+      return { ok: response.ok, status: response.status, length: body.length, tail: body.slice(-32) };
+    });
+    console.log('script.js probe', scriptProbe);
+
+    await waitForControlState(page, 'diagnostics bootstrap', () => {
+      return Boolean(window.spacerxDiagnostics?.getControlState);
+    });
+
+    await page.select('#lapsSetting', '10').catch(() => {});
+    await page.evaluate(() => {
+      const toggle = document.getElementById('toggleBroadcastIntro');
+      if (toggle && !toggle.checked) {
+        toggle.click();
+      }
+    });
+
+    await runQuickRace(page);
+    await runGrandPrixRound(page);
+    await runManagerWeek(page);
+
+    console.log('✅ Spacer-X smoke test completed successfully.');
+  } finally {
+    await browser.close();
+    await closeServer(server);
+  }
+}
+
+main().catch(error => {
+  console.error('Smoke test failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a Puppeteer-based smoke test that loads the prototype, runs a quick race, advances the Grand Prix, and simulates a manager week while asserting UI state via window.spacerxDiagnostics
- wire the smoke test into npm (Node 18+) and document prerequisites plus fallback manual steps
- deduplicate script.js DOM bindings and initialization blocks so diagnostics and initialization run without redeclaration errors

## Testing
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68d0f71a83188324a2e0c8d5a7b5397c

## Summary by Sourcery

Add automated end-to-end smoke testing and streamline application initialization to support reliable UI state diagnostics

New Features:
- Introduce a Puppeteer-based smoke test (tests/full_smoke.mjs) that runs a quick race, advances a Grand Prix event, and simulates a manager week with UI assertions
- Expose window.spacerxDiagnostics.getControlState for capturing UI and application state during tests
- Add an npm "smoke" script and Node.js (>=18) engine requirement to package.json

Enhancements:
- Refactor script.js to remove duplicate DOM bindings and consolidate all UI setup into an initializeAppState function
- Add utility functions (isElementVisible, getButtonDiagnostics) to aid in diagnostics and test assertions

Documentation:
- Document automated smoke test setup, prerequisites, and manual fallback steps in README.md and tests/MANUAL_CHECKLIST.md

Tests:
- Update MANUAL_CHECKLIST.md with automated coverage section and manual fallback checklist