### PR TITLE
Hide next GP button on reset

### DIFF
--- a/script.js
+++ b/script.js
@@ -1053,6 +1053,10 @@
       replayRaceBtn.style.display = 'none';
       replayRaceBtn.textContent = 'Replay';
     }
+    if (nextRaceBtn) {
+      nextRaceBtn.style.display = 'none';
+      nextRaceBtn.setAttribute('aria-hidden', 'true');
+    }
     if (replayControls) {
       replayControls.classList.add('hidden');
       replayControls.setAttribute('aria-hidden', 'true');
@@ -1470,6 +1474,10 @@
     if (replayRaceBtn) {
       replayRaceBtn.style.display = 'none';
       replayRaceBtn.textContent = 'Replay';
+    }
+    if (nextRaceBtn) {
+      nextRaceBtn.style.display = 'none';
+      nextRaceBtn.setAttribute('aria-hidden', 'true');
     }
     if (replayControls) {
       replayControls.classList.add('hidden');
@@ -5821,7 +5829,10 @@
     updateLeaderboardHud([]);
     resultsLabel.textContent = '';
     replayRaceBtn.style.display = 'none';
-    if (nextRaceBtn) nextRaceBtn.style.display = 'none';
+    if (nextRaceBtn) {
+      nextRaceBtn.style.display = 'none';
+      nextRaceBtn.setAttribute('aria-hidden', 'true');
+    }
     setStartButtonState(false);
     setPauseButtonState(false, 'Pause');
     resetMarshalOverlay();
@@ -5959,6 +5970,7 @@
       if (gpRaceIndex < GP_RACES) {
         const nextRaceNumber = Math.min(GP_RACES, gpRaceIndex + 1);
         nextRaceBtn.style.display = 'inline-block';
+        nextRaceBtn.setAttribute('aria-hidden', 'false');
         setStartButtonState(true, `Rennen ${nextRaceNumber} starten`);
       } else {
         gpActive = false;
@@ -7145,6 +7157,7 @@
   });
   nextRaceBtn?.addEventListener('click', () => {
     nextRaceBtn.style.display = 'none';
+    nextRaceBtn.setAttribute('aria-hidden', 'true');
     prepareGrandPrixRound();
     startRace();
   });


### PR DESCRIPTION
## Summary
- hide the next GP race button whenever race controls reset so it does not linger
- ensure the button toggles aria-hidden state consistently when shown or hidden

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d0e7178e8883249b90dce1173959c8)

## Summary by Sourcery

Ensure the Next GP race button is consistently hidden and marked aria-hidden when race controls or results are reset, and correctly exposed when the next race becomes available.

Bug Fixes:
- Hide the Next GP race button whenever race controls or results are reset so it does not remain visible unexpectedly.
- Keep the Next GP race button’s aria-hidden attribute in sync with its visibility when showing, hiding, and on click.